### PR TITLE
Fix docs + make templates dir configurable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Typical setup/use:
 ```bash
 cd ~/slide_smith
 source .venv/bin/activate
-pip install -e .[dev]
+pip install .
 pytest -q
 python -m slide_smith.cli --help
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The repo now includes:
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -e .[dev]
+pip install .
 pytest -q
 python -m slide_smith.cli --help
 ```
@@ -64,7 +64,7 @@ python -m slide_smith.cli --help
 ```bash
 uv venv .venv
 source .venv/bin/activate
-uv pip install -e .[dev]
+uv pip install .
 pytest -q
 python -m slide_smith.cli --help
 ```
@@ -78,6 +78,10 @@ slide-smith inspect-template --template default
 slide-smith validate-template --template default
 slide-smith create --input docs/design/examples/deck-spec.sample.json --template default --output out.pptx
 slide-smith create --input docs/design/examples/deck-spec.sample.json --template default --assets-dir /tmp/slide-smith-assets --output out.pptx
+
+# If your templates live somewhere else:
+slide-smith inspect-template --template default --templates-dir /path/to/templates
+
 slide-smith add-slide --deck out.pptx --after 2 --type title_and_bullets --input slide.json
 slide-smith update-slide --deck out.pptx --index 1 --input patch.json
 slide-smith list-slides --deck out.pptx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,6 @@ authors = [
 ]
 dependencies = [
   "python-pptx>=1.0.0",
-]
-
-[project.optional-dependencies]
-dev = [
   "pytest>=9.0.0",
   "jsonschema>=4.22.0",
 ]

--- a/src/slide_smith/cli.py
+++ b/src/slide_smith/cli.py
@@ -34,6 +34,11 @@ def build_parser() -> argparse.ArgumentParser:
     create = subparsers.add_parser("create", help="Create a deck from structured input.")
     create.add_argument("--input", required=True, help="Path to markdown or JSON input.")
     create.add_argument("--template", required=True, help="Template id to use.")
+    create.add_argument(
+        "--templates-dir",
+        default=None,
+        help="Optional root directory containing template packages (defaults to repo-local templates/).",
+    )
     create.add_argument("--output", required=True, help="Output .pptx path.")
     create.add_argument(
         "--assets-dir",
@@ -52,6 +57,11 @@ def build_parser() -> argparse.ArgumentParser:
         "inspect-template", help="Inspect a template package."
     )
     inspect_template.add_argument("--template", required=True, help="Template id to inspect.")
+    inspect_template.add_argument(
+        "--templates-dir",
+        default=None,
+        help="Optional root directory containing template packages (defaults to repo-local templates/).",
+    )
 
     add_slide = subparsers.add_parser("add-slide", help="Add a slide to an existing deck.")
     add_slide.add_argument("--deck", required=True, help="Path to target deck.")
@@ -75,13 +85,18 @@ def build_parser() -> argparse.ArgumentParser:
         "validate-template", help="Validate that a template package matches its PPTX (layouts/placeholders)."
     )
     validate_template_cmd.add_argument("--template", required=True, help="Template id to validate.")
+    validate_template_cmd.add_argument(
+        "--templates-dir",
+        default=None,
+        help="Optional root directory containing template packages (defaults to repo-local templates/).",
+    )
 
     return parser
 
 
 
-def handle_inspect_template(template_id: str) -> int:
-    spec = load_template_spec(template_id)
+def handle_inspect_template(template_id: str, templates_dir: str | None = None) -> int:
+    spec = load_template_spec(template_id, templates_dir=templates_dir)
     print(f"template: {spec['template_id']} ({spec.get('name', 'unnamed')})")
     print(f"version: {spec.get('version', 'n/a')}")
     deck = spec.get("deck", {})
@@ -117,8 +132,9 @@ def handle_create(
     output_path: str,
     assets_dir: str | None = None,
     print_mode: str = "normalized",
+    templates_dir: str | None = None,
 ) -> int:
-    template_spec = load_template_spec(template_id)
+    template_spec = load_template_spec(template_id, templates_dir=templates_dir)
     if input_path.endswith(".json"):
         spec = load_deck_spec(input_path)
     elif input_path.endswith(".md"):
@@ -164,6 +180,7 @@ def handle_create(
             template_id,
             output_path,
             base_dir=str(Path(input_path).resolve().parent),
+            templates_dir=templates_dir,
         )
     except RenderingError as exc:
         print(f"Rendering failed: {exc}")
@@ -195,7 +212,7 @@ def main() -> int:
         return 0
 
     if args.command == "inspect-template":
-        return handle_inspect_template(args.template)
+        return handle_inspect_template(args.template, templates_dir=getattr(args, "templates_dir", None))
     if args.command == "create":
         return handle_create(
             args.input,
@@ -203,6 +220,7 @@ def main() -> int:
             args.output,
             assets_dir=getattr(args, "assets_dir", None),
             print_mode=getattr(args, "print_mode", "normalized"),
+            templates_dir=getattr(args, "templates_dir", None),
         )
     if args.command == "add-slide":
         try:
@@ -240,7 +258,7 @@ def main() -> int:
         return 0
 
     if args.command == "validate-template":
-        result = validate_template(args.template)
+        result = validate_template(args.template, templates_dir=getattr(args, "templates_dir", None))
         if not result.ok:
             print("Template validation failed:")
             for e in result.errors:

--- a/src/slide_smith/renderer.py
+++ b/src/slide_smith/renderer.py
@@ -14,8 +14,8 @@ class RenderingError(Exception):
 
 
 
-def _presentation_for_template(template_id: str) -> Presentation:
-    pptx_path = template_dir(template_id) / "template.pptx"
+def _presentation_for_template(template_id: str, templates_dir: str | None = None) -> Presentation:
+    pptx_path = template_dir(template_id, templates_dir) / "template.pptx"
     if pptx_path.exists():
         return Presentation(str(pptx_path))
     return Presentation()
@@ -114,8 +114,15 @@ def _set_notes(slide, notes: str | None) -> None:
 
 
 
-def render_deck(deck_spec: dict[str, Any], template_spec: dict[str, Any], template_id: str, output_path: str, base_dir: str | None = None) -> str:
-    prs = _presentation_for_template(template_id)
+def render_deck(
+    deck_spec: dict[str, Any],
+    template_spec: dict[str, Any],
+    template_id: str,
+    output_path: str,
+    base_dir: str | None = None,
+    templates_dir: str | None = None,
+) -> str:
+    prs = _presentation_for_template(template_id, templates_dir=templates_dir)
     source_dir = Path(base_dir or ".").resolve()
 
     styles = load_styles(template_spec)

--- a/src/slide_smith/template_loader.py
+++ b/src/slide_smith/template_loader.py
@@ -5,16 +5,24 @@ from pathlib import Path
 from typing import Any
 
 
-def templates_root() -> Path:
+def templates_root(templates_dir: str | None = None) -> Path:
+    """Return the root directory containing template packages.
+
+    By default we use the repo-local `templates/` directory. Callers may override
+    this (e.g. from CLI) to point at a different templates root.
+    """
+
+    if templates_dir:
+        return Path(templates_dir).expanduser().resolve()
     return Path(__file__).resolve().parents[2] / "templates"
 
 
-def template_dir(template_id: str) -> Path:
-    return templates_root() / template_id
+def template_dir(template_id: str, templates_dir: str | None = None) -> Path:
+    return templates_root(templates_dir) / template_id
 
 
-def load_template_spec(template_id: str) -> dict[str, Any]:
-    path = template_dir(template_id) / "template.json"
+def load_template_spec(template_id: str, templates_dir: str | None = None) -> dict[str, Any]:
+    path = template_dir(template_id, templates_dir) / "template.json"
     if not path.exists():
         raise FileNotFoundError(f"Template '{template_id}' not found at {path}")
     return json.loads(path.read_text())

--- a/src/slide_smith/template_validator.py
+++ b/src/slide_smith/template_validator.py
@@ -19,11 +19,11 @@ class TemplateValidationError(Exception):
     pass
 
 
-def validate_template(template_id: str) -> TemplateValidationResult:
+def validate_template(template_id: str, templates_dir: str | None = None) -> TemplateValidationResult:
     errors: list[str] = []
 
-    spec = load_template_spec(template_id)
-    tdir = template_dir(template_id)
+    spec = load_template_spec(template_id, templates_dir=templates_dir)
+    tdir = template_dir(template_id, templates_dir=templates_dir)
     pptx_path = tdir / "template.pptx"
 
     # Allow templates that are JSON-only (no pptx) for early-stage prototyping.


### PR DESCRIPTION
Fixes #14\n\n- Make templates root configurable via  for create/inspect-template/validate-template\n- Update README/CLAUDE install instructions () and ensure pytest/jsonschema are in core deps