### PR TITLE
Simplify README; link usage to SKILL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,105 +2,52 @@
 
 [![CI](https://github.com/ninjapapa/slide_smith/actions/workflows/ci.yml/badge.svg)](https://github.com/ninjapapa/slide_smith/actions/workflows/ci.yml)
 
-slide_smith is a demo agent-first application for Python-based PowerPoint creation.
+slide_smith is an **agent-first** Python tool for creating and iteratively editing PowerPoint decks.
 
-It uses the `python-pptx` (`pptx`) library as the core PowerPoint generation engine, but the goal here is not just deck generation — it is to wrap that capability in an agent-first app that agents can operate reliably.
+- Core engine: `python-pptx`
+- Core pipeline: **JSON Deck Spec → PPTX**
+- Template model: `template.pptx` (render truth) + `template.json` (semantic truth)
 
-An agent-first application is designed to be usable not just by humans, but directly by calling agents: it exposes clear operable interfaces, good documentation, informative errors, and feedback loops that let agents reliably create, inspect, and refine outputs over multiple steps.
+## Usage (human + agent)
 
-**Agent-first mantra**
-- *Designed by human*
-- *Created by agents*
-- *For agents to use*
-- *Learn from agents feedback*
-- *Refine and maintain by agents*
-
-## Early project status
-
-## Agent-first posture
-
-**Designed by human. Created by agents. For agents to use.**
-
-This repo is intentionally shaped to be operated by calling agents:
-- *Designed by human*
-- *Created by agents*
-- *For agents to use*
-- *Learn from agents feedback*
-- *Refine and maintain by agents*
-
-### JSON-first workflow
-
-The core pipeline is **JSON Deck Spec -> PPTX**. Markdown ingestion is optional and can be handled by caller-side skills/tools.
-
-### Agent skill (for Claude Code / OpenClaw)
-
-This repo ships an agent skill file that teaches calling agents how to operate Slide Smith via CLI:
+All “how to use it” instructions live in the canonical skill doc:
 
 - `skills/slide-smith/SKILL.md`
 
-The repo now includes:
-- design docs under `docs/design/`
-- local issue drafts under `docs/issues/`
-- a Python CLI scaffold in `src/slide_smith/`
-- a default template package under `templates/default/`
-- an initial rendering path using `python-pptx`
-- tests under `tests/`
-- a project context file in `CLAUDE.md`
+That doc is written to be usable by both humans and calling agents (command examples, recommended workflow, fixtures).
+
+## Repo layout
+
+- Design docs: `docs/design/`
+- Local issue drafts: `docs/issues/`
+- Package: `src/slide_smith/`
+- Default template: `templates/default/`
+- Tests: `tests/`
+- Project context: `CLAUDE.md`
 
 ## Local development
 
-### Option 1: project-local venv with `python3 -m venv`
+### Option 1: project-local venv
 
 ```bash
+cd ~/slide_smith
 python3 -m venv .venv
 source .venv/bin/activate
 pip install .
 pytest -q
-python -m slide_smith.cli --help
+slide-smith --help
 ```
 
 ### Option 2: using `uv`
 
 ```bash
+cd ~/slide_smith
 uv venv .venv
 source .venv/bin/activate
 uv pip install .
 pytest -q
-python -m slide_smith.cli --help
+slide-smith --help
 ```
-
-## Current CLI
-
-Prefer the installed entrypoint:
-
-```bash
-slide-smith inspect-template --template default
-slide-smith validate-template --template default
-slide-smith create --input docs/design/examples/deck-spec.sample.json --template default --output out.pptx
-slide-smith create --input docs/design/examples/deck-spec.sample.json --template default --assets-dir /tmp/slide-smith-assets --output out.pptx
-
-# If your templates live somewhere else:
-slide-smith inspect-template --template default --templates-dir /path/to/templates
-
-slide-smith add-slide --deck out.pptx --after 2 --type title_and_bullets --input slide.json
-slide-smith update-slide --deck out.pptx --index 1 --input patch.json
-slide-smith list-slides --deck out.pptx
-slide-smith delete-slide --deck out.pptx --index 0
-```
-
-(You can still run via `python -m slide_smith.cli ...` if needed.)
-
-## Current design direction
-
-- input: JSON (primary); markdown is optional and best handled caller-side
-- normalization target: internal deck spec
-- template model: `template.pptx` + `template.json`
-- rendering approach: placeholder-first
-- MVP archetypes:
-  - `title`
-  - `section`
-  - `title_and_bullets`
-  - `image_left_text_right`
 
 ## Notes
 

--- a/skills/slide-smith/SKILL.md
+++ b/skills/slide-smith/SKILL.md
@@ -25,7 +25,7 @@ Markdown ingestion is optional; prefer caller-side skills/tools to convert Markd
 cd ~/slide_smith
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -e '.[dev]'
+pip install .
 pytest -q
 ```
 
@@ -37,6 +37,13 @@ pytest -q
 slide-smith create \
   --input docs/design/examples/deck-spec.full.sample.json \
   --template default \
+  --output /tmp/out.pptx
+
+# External templates root:
+slide-smith create \
+  --input docs/design/examples/deck-spec.full.sample.json \
+  --template default \
+  --templates-dir /path/to/templates \
   --output /tmp/out.pptx
 ```
 
@@ -66,10 +73,20 @@ slide-smith create \
 slide-smith inspect-template --template default
 ```
 
+If your templates live outside the repo, pass a templates root:
+
+```bash
+slide-smith inspect-template --template default --templates-dir /path/to/templates
+```
+
 ### Validate a template package
 
 ```bash
 slide-smith validate-template --template default
+```
+
+```bash
+slide-smith validate-template --template default --templates-dir /path/to/templates
 ```
 
 Notes:


### PR DESCRIPTION
Update README to focus on: what Slide Smith is, repo layout, and local dev.

Move/point all “how to use” content to the canonical doc at skills/slide-smith/SKILL.md (intended for both humans and agents).

Also updates SKILL.md to match current install instructions and document --templates-dir.
