### PR TITLE
North star: make PPTX→template bootstrap a v1 goal

### DIFF
--- a/docs/design/north-star.md
+++ b/docs/design/north-star.md
@@ -30,12 +30,29 @@ The app should be something an agent can call, inspect, correct, and call again.
 
 For the first version, the app should focus on a small number of high-value capabilities:
 
-- **Create from scratch** from markdown or JSON presentation descriptions
+- **Create** a deck from a JSON presentation description
 - **Apply a template** to generate a deck in a chosen style
-- **Modify an existing deck** in simple ways
-- **Add pages** and **delete pages** as part of iterative editing
+- **Iteratively edit an existing deck** in simple ways (add/update/list/delete slides)
 
-This keeps the MVP simple while still supporting useful agent workflows.
+This keeps the MVP narrow while still supporting useful agent workflows.
+
+## V1 Release Goal: Bootstrap templates from an example PPTX
+
+For v1, the key missing piece is enabling a *human* (working through an agent like OpenClaw / Claude Code) to bring their own PPTX and turn it into a usable Slide Smith template package.
+
+**Primary user experience (agent-mediated):**
+1. User provides a filesystem path to an example `.pptx` they want to use as a template seed.
+2. The agent runs a Slide Smith command to **bootstrap a template package** from that PPTX.
+3. The agent (and/or user) reviews the generated output, makes small edits, validates it, and then uses it to render decks.
+
+**Definition of “bootstrap a template package” (v1):**
+- Copy the input PPTX into a new template folder as `template.pptx`.
+- Generate a starter `template.json` that inventories slide layouts and placeholders (including placeholder indices) so rendering can target the right placeholders deterministically.
+- Produce inspectable output so an agent can guide the user through mapping layouts → archetypes (manual refinement is expected).
+
+**Non-goals for v1 bootstrap:**
+- Fully automatic, high-fidelity reverse engineering of arbitrary decks.
+- Perfect archetype detection without human/agent review.
 
 ## Template Ambition
 
@@ -66,9 +83,10 @@ The MVP does not need to fully solve template extraction, but the design should 
 ## Proposed MVP Scope
 
 ### Inputs
-- Markdown presentation description
 - JSON presentation description
+- Optional: Markdown presentation description (nice-to-have; not required for v1)
 - Optional template selection
+- Optional: example PPTX path (for template bootstrap)
 
 ### Outputs
 - PowerPoint deck (`.pptx`)
@@ -90,11 +108,20 @@ The MVP does not need to fully solve template extraction, but the design should 
 A simple CLI could look something like:
 
 ```bash
-slide-smith create --input brief.md --template default --output out.pptx
+# Render
 slide-smith create --input brief.json --template default --output out.pptx
-slide-smith add-slide --deck out.pptx --after 3 --input slide.md
+
+# Iterative edits
+slide-smith add-slide --deck out.pptx --after 3 --type title_and_bullets --input slide.json
+slide-smith update-slide --deck out.pptx --index 1 --input patch.json
 slide-smith delete-slide --deck out.pptx --index 4
-slide-smith inspect-template --deck example.pptx
+
+# Template operations
+slide-smith inspect-template --template default
+slide-smith validate-template --template default
+
+# V1 goal: bootstrap a template package from an example PPTX
+slide-smith bootstrap-template --pptx /path/to/example.pptx --template-id my_template --out-dir ./templates
 ```
 
 This is only directional, but it captures the type of interface agents should be able to use.


### PR DESCRIPTION
Updates docs/design/north-star.md to explicitly set the v1 release goal: an agent-mediated workflow where a user provides a PPTX path and Slide Smith can bootstrap a template package (template.pptx + starter template.json + inspectable inventory).

This separates the *goal* (user experience + definition of done) from the implementation plan.