### PR TITLE
Implement bootstrap-template command (#21)

### DIFF
--- a/src/slide_smith/cli.py
+++ b/src/slide_smith/cli.py
@@ -91,6 +91,38 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional root directory containing template packages (defaults to repo-local templates/).",
     )
 
+    bootstrap = subparsers.add_parser(
+        "bootstrap-template",
+        help="Bootstrap a template package (template.pptx + starter template.json) from an example PPTX.",
+    )
+    bootstrap.add_argument("--pptx", required=True, help="Path to example .pptx to bootstrap from.")
+    bootstrap.add_argument("--template-id", required=True, help="Template id for the new template package.")
+    bootstrap.add_argument("--out-dir", required=True, help="Directory to write the new template package into.")
+    bootstrap.add_argument(
+        "--include-layout",
+        action="append",
+        default=[],
+        help="Include only layouts with this exact name (repeatable). If omitted, all layouts are included.",
+    )
+    bootstrap.add_argument(
+        "--exclude-layout",
+        action="append",
+        default=[],
+        help="Exclude layouts with this exact name (repeatable).",
+    )
+    bootstrap.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite the output template folder if it already exists.",
+    )
+    bootstrap.add_argument(
+        "--print",
+        dest="print_mode",
+        choices=["report", "json", "none"],
+        default="report",
+        help="Output mode: report (human), json (machine), or none.",
+    )
+
     return parser
 
 
@@ -269,6 +301,55 @@ def main() -> int:
             for e in result.errors:
                 print(e)
         print(json.dumps({"template": args.template, "status": "ok"}, indent=2))
+        return 0
+
+    if args.command == "bootstrap-template":
+        from slide_smith.template_bootstrapper import BootstrapError, bootstrap_template
+
+        try:
+            res = bootstrap_template(
+                pptx_path=args.pptx,
+                template_id=args.template_id,
+                out_dir=args.out_dir,
+                include_layouts=getattr(args, "include_layout", None) or [],
+                exclude_layouts=getattr(args, "exclude_layout", None) or [],
+                overwrite=getattr(args, "overwrite", False),
+            )
+        except BootstrapError as exc:
+            print(f"Bootstrap failed: {exc}")
+            return 1
+
+        mode = getattr(args, "print_mode", "report")
+        if mode == "none":
+            return 0
+        if mode == "json":
+            print(
+                json.dumps(
+                    {
+                        "template_dir": res.template_dir,
+                        "template_pptx": res.template_pptx,
+                        "template_json": res.template_json,
+                        "included_layouts": res.included_layouts,
+                        "excluded_layouts": res.excluded_layouts,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return 0
+
+        # report
+        print(f"template_dir: {res.template_dir}")
+        print(f"- template.pptx: {res.template_pptx}")
+        print(f"- template.json: {res.template_json}")
+        if res.included_layouts:
+            print("included_layouts:")
+            for n in res.included_layouts:
+                print(f"- {n}")
+        if res.excluded_layouts:
+            print("excluded_layouts:")
+            for n in res.excluded_layouts:
+                print(f"- {n}")
         return 0
 
     print(f"Command '{args.command}' is scaffolded but not implemented yet.")

--- a/src/slide_smith/template_bootstrapper.py
+++ b/src/slide_smith/template_bootstrapper.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from pptx import Presentation
+
+
+def _slugify(text: str) -> str:
+    s = text.strip().lower()
+    s = re.sub(r"[^a-z0-9]+", "_", s)
+    s = re.sub(r"_+", "_", s).strip("_")
+    return s or "layout"
+
+
+def _enum_name(value: Any) -> str:
+    name = getattr(value, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    return str(value)
+
+
+def _slot_name_and_type(ph_type_name: str) -> tuple[str, str]:
+    # Keep these conservative and deterministic.
+    if ph_type_name in {"TITLE", "CENTER_TITLE"}:
+        return "title", "text"
+    if ph_type_name == "SUBTITLE":
+        return "subtitle", "text"
+    if ph_type_name == "BODY":
+        return "body", "bullets"
+    if ph_type_name == "PICTURE":
+        return "image", "image"
+    return "slot", "unknown"
+
+
+@dataclass(frozen=True)
+class BootstrapResult:
+    template_dir: str
+    template_pptx: str
+    template_json: str
+    included_layouts: list[str]
+    excluded_layouts: list[str]
+
+
+class BootstrapError(Exception):
+    pass
+
+
+def bootstrap_template(
+    *,
+    pptx_path: str,
+    template_id: str,
+    out_dir: str,
+    include_layouts: Iterable[str] | None = None,
+    exclude_layouts: Iterable[str] | None = None,
+    overwrite: bool = False,
+    name: str | None = None,
+    version: str = "0.1",
+) -> BootstrapResult:
+    src = Path(pptx_path).expanduser()
+    if not src.exists():
+        raise BootstrapError(f"PPTX not found: {src}")
+    if not src.is_file():
+        raise BootstrapError(f"PPTX path is not a file: {src}")
+
+    dest_root = Path(out_dir).expanduser().resolve()
+    tdir = dest_root / template_id
+
+    if tdir.exists():
+        if not overwrite:
+            raise BootstrapError(f"Output template dir already exists: {tdir} (pass --overwrite to replace)")
+        # Overwrite means replace just this template folder.
+        shutil.rmtree(tdir)
+
+    tdir.mkdir(parents=True, exist_ok=True)
+
+    # Copy PPTX.
+    pptx_out = tdir / "template.pptx"
+    shutil.copyfile(str(src.resolve()), str(pptx_out))
+
+    prs = Presentation(str(pptx_out))
+
+    include_set = {s.strip() for s in (include_layouts or []) if s.strip()}
+    exclude_set = {s.strip() for s in (exclude_layouts or []) if s.strip()}
+
+    included: list[str] = []
+    excluded: list[str] = []
+    archetypes: list[dict[str, Any]] = []
+
+    # Determine which layouts to include.
+    for layout in prs.slide_layouts:
+        lname = layout.name
+        if include_set and lname not in include_set:
+            excluded.append(lname)
+            continue
+        if lname in exclude_set:
+            excluded.append(lname)
+            continue
+
+        included.append(lname)
+
+        # Build archetype.
+        aid = f"layout__{_slugify(lname)}"
+        slots: list[dict[str, Any]] = []
+        name_counts: dict[str, int] = {}
+
+        for ph in sorted(layout.placeholders, key=lambda p: int(p.placeholder_format.idx)):
+            ph_type = _enum_name(ph.placeholder_format.type)
+            base_name, slot_type = _slot_name_and_type(ph_type)
+
+            # Ensure unique slot names per archetype.
+            n = name_counts.get(base_name, 0) + 1
+            name_counts[base_name] = n
+            slot_name = base_name if n == 1 else f"{base_name}_{n}"
+
+            slots.append(
+                {
+                    "name": slot_name,
+                    "type": slot_type,
+                    "required": False,
+                    "placeholder_idx": int(ph.placeholder_format.idx),
+                }
+            )
+
+        archetypes.append(
+            {
+                "id": aid,
+                "description": f"Bootstrap from layout '{lname}'",
+                "layout": lname,
+                "slots": slots,
+            }
+        )
+
+    if not archetypes:
+        raise BootstrapError(
+            "No layouts selected for bootstrap. Check --include-layout(s)/--exclude-layout(s) filters."
+        )
+
+    spec: dict[str, Any] = {
+        "template_id": template_id,
+        "name": name or template_id,
+        "version": version,
+        "deck": {},
+        "styles": {},
+        "archetypes": archetypes,
+    }
+
+    template_json_path = tdir / "template.json"
+    template_json_path.write_text(json.dumps(spec, indent=2, sort_keys=True) + "\n")
+
+    return BootstrapResult(
+        template_dir=str(tdir),
+        template_pptx=str(pptx_out),
+        template_json=str(template_json_path),
+        included_layouts=included,
+        excluded_layouts=excluded,
+    )

--- a/src/slide_smith/template_validator.py
+++ b/src/slide_smith/template_validator.py
@@ -82,9 +82,15 @@ def validate_template(template_id: str, templates_dir: str | None = None) -> Tem
             if not isinstance(idx, int):
                 errors.append(f"archetype '{aid}': slot '{slot.get('name','?')}' placeholder_idx must be int")
                 continue
-            try:
-                _ = layout.placeholders[idx]
-            except KeyError:
+            found = False
+            for ph in layout.placeholders:
+                try:
+                    if int(ph.placeholder_format.idx) == idx:
+                        found = True
+                        break
+                except Exception:
+                    continue
+            if not found:
                 errors.append(
                     f"archetype '{aid}': layout '{layout_name}' missing placeholder idx={idx} for slot '{slot.get('name','?')}'"
                 )

--- a/tests/test_bootstrap_template.py
+++ b/tests/test_bootstrap_template.py
@@ -1,0 +1,53 @@
+import json
+import tempfile
+from pathlib import Path
+
+from pptx import Presentation
+
+from slide_smith.template_bootstrapper import bootstrap_template
+from slide_smith.template_validator import validate_template
+
+
+def _make_temp_pptx() -> str:
+    prs = Presentation()
+    prs.slides.add_slide(prs.slide_layouts[0])
+    tmpdir = tempfile.mkdtemp(prefix="slide-smith-")
+    p = Path(tmpdir) / "seed.pptx"
+    prs.save(str(p))
+    return str(p)
+
+
+def test_bootstrap_template_writes_package_and_validates() -> None:
+    seed = _make_temp_pptx()
+    out_dir = tempfile.mkdtemp(prefix="slide-smith-out-")
+
+    res = bootstrap_template(pptx_path=seed, template_id="t1", out_dir=out_dir)
+
+    tdir = Path(res.template_dir)
+    assert (tdir / "template.pptx").exists()
+    assert (tdir / "template.json").exists()
+
+    spec = json.loads((tdir / "template.json").read_text())
+    assert spec["template_id"] == "t1"
+    assert isinstance(spec["archetypes"], list)
+    assert len(spec["archetypes"]) > 0
+
+    v = validate_template("t1", templates_dir=out_dir)
+    assert v.ok
+
+
+def test_bootstrap_template_overwrite_behavior() -> None:
+    seed = _make_temp_pptx()
+    out_dir = tempfile.mkdtemp(prefix="slide-smith-out-")
+
+    _ = bootstrap_template(pptx_path=seed, template_id="t2", out_dir=out_dir)
+
+    # Without overwrite should fail.
+    try:
+        _ = bootstrap_template(pptx_path=seed, template_id="t2", out_dir=out_dir)
+        assert False, "expected bootstrap to fail without overwrite"
+    except Exception:
+        pass
+
+    # With overwrite should succeed.
+    _ = bootstrap_template(pptx_path=seed, template_id="t2", out_dir=out_dir, overwrite=True)


### PR DESCRIPTION
Fixes #21

Implements `slide-smith bootstrap-template`.

- Copies input PPTX into a new template package as template.pptx
- Generates starter template.json with one archetype per selected layout and one slot per placeholder (with placeholder_idx)
- Supports include/exclude layout filters and overwrite
- Adds tests and fixes placeholder-idx checking in template_validator (layout placeholders are not indexable by placeholder idx)
