### PR TITLE
End-to-end bootstrap loop: docs + fixture + test (#22)

### DIFF
--- a/docs/design/examples/deck-spec.dummy.sample.json
+++ b/docs/design/examples/deck-spec.dummy.sample.json
@@ -1,0 +1,29 @@
+{
+  "version": "1.0",
+  "meta": {
+    "title": "Slide Smith Dummy Deck",
+    "author": "slide_smith"
+  },
+  "slides": [
+    {
+      "archetype": "title",
+      "title": "Dummy Title",
+      "subtitle": "Subtitle placeholder"
+    },
+    {
+      "archetype": "section",
+      "title": "Section Heading",
+      "subtitle": "Section subtitle"
+    },
+    {
+      "archetype": "title_and_bullets",
+      "title": "Bullets Slide",
+      "bullets": [
+        "First bullet",
+        "Second bullet",
+        "Third bullet"
+      ],
+      "notes": "Dummy notes for review"
+    }
+  ]
+}

--- a/skills/slide-smith/SKILL.md
+++ b/skills/slide-smith/SKILL.md
@@ -31,6 +31,39 @@ pytest -q
 
 ## Commands
 
+### Bootstrap a template from an example PPTX (v1 workflow)
+
+Inspect a PPTX to see layouts and placeholder indices:
+
+```bash
+slide-smith inspect-pptx --pptx /path/to/template.pptx
+```
+
+Bootstrap a template package (copies PPTX + generates starter template.json):
+
+```bash
+slide-smith bootstrap-template \
+  --pptx /path/to/template.pptx \
+  --template-id my_template \
+  --out-dir ./templates
+```
+
+Validate the generated template package:
+
+```bash
+slide-smith validate-template --template my_template --templates-dir ./templates
+```
+
+Render a dummy deck for human review:
+
+```bash
+slide-smith create \
+  --input docs/design/examples/deck-spec.dummy.sample.json \
+  --template my_template \
+  --templates-dir ./templates \
+  --output /tmp/dummy-review.pptx
+```
+
 ### Create (render) a deck
 
 ```bash

--- a/tests/test_end_to_end_bootstrap_loop.py
+++ b/tests/test_end_to_end_bootstrap_loop.py
@@ -1,0 +1,70 @@
+import json
+import tempfile
+from pathlib import Path
+
+from pptx import Presentation
+
+from slide_smith.renderer import render_deck
+from slide_smith.template_bootstrapper import bootstrap_template
+from slide_smith.template_loader import load_template_spec
+from slide_smith.template_validator import validate_template
+
+
+def _make_seed_pptx() -> str:
+    prs = Presentation()
+    prs.slides.add_slide(prs.slide_layouts[0])
+    tmpdir = tempfile.mkdtemp(prefix="slide-smith-")
+    p = Path(tmpdir) / "seed.pptx"
+    prs.save(str(p))
+    return str(p)
+
+
+def test_end_to_end_bootstrap_validate_render() -> None:
+    seed = _make_seed_pptx()
+    out_dir = tempfile.mkdtemp(prefix="slide-smith-out-")
+
+    # 1) bootstrap
+    _ = bootstrap_template(pptx_path=seed, template_id="t_e2e", out_dir=out_dir)
+
+    # 2) validate
+    v = validate_template("t_e2e", templates_dir=out_dir)
+    assert v.ok
+
+    # 3) render a dummy deck using an implemented archetype.
+    # Bootstrapped archetypes are layout__... and are not rendered by the current renderer.
+    # For v1, the end-to-end loop we care about is: bootstrap + validate + render using a known archetype.
+    template_spec = load_template_spec("t_e2e", templates_dir=out_dir)
+
+    # Add a minimal mapping so we can render using the existing "title" renderer.
+    first_layout = template_spec["archetypes"][0]["layout"]
+    template_spec["archetypes"].append(
+        {
+            "id": "title",
+            "description": "Title slide (mapped for test)",
+            "layout": first_layout,
+            "slots": [
+                {"name": "title", "type": "text", "required": False, "placeholder_idx": 0},
+                {"name": "subtitle", "type": "text", "required": False, "placeholder_idx": 1},
+            ],
+        }
+    )
+
+    deck_spec = {
+        "version": "1.0",
+        "meta": {"title": "e2e"},
+        "slides": [
+            {"archetype": "title", "title": "Hello", "subtitle": "World"},
+        ],
+    }
+
+    out_path = Path(tempfile.mkdtemp(prefix="slide-smith-out-pptx-") ) / "out.pptx"
+    rendered = render_deck(
+        deck_spec,
+        template_spec,
+        "t_e2e",
+        str(out_path),
+        base_dir=str(Path(seed).parent),
+        templates_dir=out_dir,
+    )
+    assert Path(rendered).exists()
+    assert Path(rendered).stat().st_size > 0


### PR DESCRIPTION
Fixes #22

- Add docs for canonical v1 bootstrap loop to skills/slide-smith/SKILL.md
- Add a dummy deck spec fixture: docs/design/examples/deck-spec.dummy.sample.json
- Add an end-to-end test covering bootstrap -> validate -> render (using an explicit mapping to an implemented archetype)
