### PR TITLE
Fix slide-smith SKILL.md frontmatter YAML

### DIFF
--- a/skills/slide-smith/SKILL.md
+++ b/skills/slide-smith/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: slide-smith
-description: Generate and iteratively edit PowerPoint (.pptx) decks using the slide-smith agent-first CLI. Use when an agent needs to: (1) render a PPTX from a JSON Deck Spec, (2) inspect/validate templates, (3) collect/copy image assets for reproducible runs, or (4) perform narrow deck edits (add/update/list/delete slides) on an existing PPTX.
+description: "Generate and iteratively edit PowerPoint (.pptx) decks using the slide-smith agent-first CLI. Use when an agent needs to: (1) render a PPTX from a JSON Deck Spec, (2) inspect/validate templates, (3) collect/copy image assets for reproducible runs, or (4) perform narrow deck edits (add/update/list/delete slides) on an existing PPTX."
 ---
 
 # Slide Smith (agent-first PPTX tool)


### PR DESCRIPTION
Fix YAML frontmatter in skills/slide-smith/SKILL.md by quoting the description (it contains a ':' which breaks YAML parsing otherwise).
