### PR TITLE
Design doc: v1.1 archetype library + caller-agent hints

### DIFF
--- a/docs/design/v1.1-archetype-library-and-hints.md
+++ b/docs/design/v1.1-archetype-library-and-hints.md
@@ -1,0 +1,238 @@
+# v1.1 — Archetype Library + Caller-Agent Hints (Design)
+
+## Context
+`slide_smith` is an **agent-first** PPTX creation tool. v1.0 established:
+
+- JSON-first rendering pipeline (Deck Spec → PPTX)
+- Template model: `template.pptx` (render truth) + `template.json` (semantic truth)
+- Template bootstrap (`bootstrap-template`) + mapping (`map-template`) + validation (`validate-template`)
+- Renderer driven by `template.json` slot mappings (`placeholder_idx`)
+
+v1.1 expands the system in two directions:
+
+1) A **richer archetype library** (beyond the current small “standard archetypes”).
+2) A **caller-agent assisted mapping workflow** where `slide-smith` can request help, and the caller agent can provide *hints* (potentially derived from LLM vision on exported layout previews).
+
+Non-goals (explicitly out of scope for v1.1):
+
+- Chart archetypes
+- Vertical timeline archetypes
+- `slide-smith` calling external LLM APIs directly (caller-agent owns that)
+
+---
+
+## Goals
+
+### G1 — More comprehensive archetype set
+Provide a useful “extended standard” set covering common consulting/product decks:
+
+- 2/3/4 column layouts (buckets/pillars)
+- Horizontal timeline layouts
+- Table layouts (table-only, table+description)
+
+### G2 — Best-effort matching for imported templates
+Imported PPTX templates often have nonstandard placeholder indices and layout conventions.
+
+v1.1 should make it easy to:
+
+- bootstrap a template
+- infer/confirm mappings to an expanded archetype set
+- validate for compatibility
+- render example decks
+
+### G3 — Ask-for-help contract with caller agent
+When `slide-smith` can’t confidently map extended archetypes, it should:
+
+- emit a machine-readable **help request** describing what it needs
+- optionally export **layout preview images + manifest**
+- accept machine-readable **hints** from the caller agent to guide mapping
+
+---
+
+## Archetype library (v1.1)
+
+### Naming
+We treat these as **extended standard archetypes** (in addition to current `title`, `section`, `title_and_bullets`, `image_left_text_right`).
+
+Proposed IDs (final list can be adjusted, but should stay stable once published):
+
+#### Columns / buckets / pillars
+- `two_col` — left/right text columns
+- `three_col` — 3 text columns
+- `four_col` — 4 text columns
+- `pillars_3` — title + 3 pillar blocks (each with a heading + body)
+- `pillars_4` — title + 4 pillar blocks
+
+#### Tables
+- `table` — title + table content
+- `table_plus_description` — title + table + description/body area
+
+#### Timeline
+- `timeline_horizontal` — title + N milestones
+
+### Slot model
+Slots remain semantic and map to placeholders via `placeholder_idx`.
+
+We should keep slot naming predictable for agents:
+
+- common slots: `title`, `subtitle`, `body`, `bullets`, `image`
+- repeated groups use a numbered suffix:
+  - columns: `col1_title`, `col1_body`, …
+  - pillars: `pillar1_title`, `pillar1_body`, …
+  - timeline: `milestone1_title`, `milestone1_body`, … (or `milestone1_date`, `milestone1_label` if supported)
+
+Table slot representation options:
+
+- v1.1 MVP: represent table content as **text** in a slot (`table_text`) for deterministic rendering.
+- future: represent table as structured cells (`table: {rows:[...]}`) once we implement true PPTX table objects.
+
+---
+
+## CLI additions (v1.1)
+
+### 1) Export layout previews
+Command:
+
+```bash
+slide-smith export-previews --template <id> --out-dir <dir> --mode layouts
+```
+
+Output:
+
+- One PNG per layout (or per selected layout)
+- `manifest.json` with:
+  - template id
+  - template.pptx path
+  - layout name
+  - placeholder inventory (idx/type/name)
+  - png path
+
+This is designed for the **caller agent** to run vision / classification.
+
+Implementation note: exporting images can be done via a headless conversion step (e.g. LibreOffice) if available; otherwise, provide a stub that exports only the manifest and returns a “conversion unavailable” warning.
+
+### 2) Help request emission
+When mapping is ambiguous or incomplete, allow producing a structured request:
+
+```bash
+slide-smith map-template --template <id> --print help-request
+```
+
+Help request should include:
+
+- what archetypes are missing/unmapped
+- what layouts exist
+- placeholder inventories
+- recommended next actions:
+  - run `export-previews`
+  - provide `hints.json`
+
+### 3) Hints ingestion
+Add:
+
+```bash
+slide-smith map-template --template <id> --hints hints.json [--interactive] [--write]
+```
+
+Hints should:
+
+- boost scoring / choose default layout for an archetype
+- optionally suggest placeholder indices for specific slots
+- never silently override explicit mappings unless the user chooses to write/accept
+
+---
+
+## Data contracts
+
+### Help request (proposal)
+Example:
+
+```json
+{
+  "help_request_version": 1,
+  "template_id": "acn1",
+  "template_pptx": ".../templates/acn1/template.pptx",
+  "missing_archetypes": ["three_col", "table", "timeline_horizontal"],
+  "layouts": [
+    {
+      "name": "Title and Content",
+      "placeholders": [{"idx": 10, "ph_type": "TITLE", "name": "Title"}]
+    }
+  ],
+  "next_actions": [
+    {
+      "action": "export_previews",
+      "command": "slide-smith export-previews --template acn1 --out-dir /tmp/acn1-previews --mode layouts"
+    },
+    {
+      "action": "provide_hints",
+      "hint_schema": "v1"
+    }
+  ]
+}
+```
+
+### Hints (proposal)
+Example:
+
+```json
+{
+  "hints_version": 1,
+  "template_id": "acn1",
+  "layouts": {
+    "Three Columns": {
+      "suggested_standard_archetypes": [
+        {"id": "three_col", "confidence": 0.86, "notes": "3 equal columns"}
+      ],
+      "slot_hints": {
+        "col1_body": {"placeholder_idx": 10},
+        "col2_body": {"placeholder_idx": 11},
+        "col3_body": {"placeholder_idx": 12}
+      }
+    }
+  }
+}
+```
+
+---
+
+## Implementation plan (work breakdown)
+
+### Phase 1 — Archetype spec + docs
+- Add `docs/design/archetypes.md` (or extend this doc) listing extended archetypes and slot conventions.
+- Update `template_validator` standard profile to optionally validate extended archetypes (new profile, e.g. `--profile extended`).
+
+### Phase 2 — Renderer support (MVP)
+- Implement rendering functions for:
+  - `two_col`, `three_col`, `four_col`
+  - `pillars_3`, `pillars_4`
+  - `timeline_horizontal`
+  - `table` and `table_plus_description` (MVP: text-based)
+- Add fixtures + tests for nonstandard `placeholder_idx` mappings.
+
+### Phase 3 — Mapping + inference upgrades
+- Extend inference heuristics in `template_mapper`:
+  - identify column layouts based on placeholder inventory counts/types
+  - identify table-ish layouts (TABLE placeholders) if present
+  - identify timeline-ish layouts by multiple repeated text placeholders
+- Ensure output is reviewable (`generated` markers + inference notes).
+
+### Phase 4 — Caller-agent hint loop
+- Implement `export-previews` + manifest.
+- Implement `map-template --print help-request`.
+- Implement `--hints` ingestion and scoring/slot prefill.
+
+### Phase 5 — Examples
+- Add an “extended kitchen sink” deck spec in `docs/design/examples/`.
+- Add docs: recommended workflow for callers:
+  - bootstrap → map → validate
+  - if help needed: export-previews → caller vision → hints → re-run map
+
+---
+
+## Success criteria
+
+- A new imported template can be bootstrapped and mapped to the extended archetype set with minimal manual work.
+- When mapping is ambiguous, `slide-smith` clearly explains what’s missing and how a caller agent can help.
+- `validate-template` can catch missing mappings for required archetype slots.
+- Example decks exist that exercise the full extended archetype set.


### PR DESCRIPTION
Adds a v1.1 design doc covering: extended archetype library (columns/pillars/tables/horizontal timeline) and an external caller-agent hint loop (help-request + preview export + hints ingestion).

Doc: docs/design/v1.1-archetype-library-and-hints.md