### PR TITLE
v1.1: MVP renderer support for extended archetypes

### DIFF
--- a/src/slide_smith/renderer.py
+++ b/src/slide_smith/renderer.py
@@ -212,6 +212,73 @@ def _render_image_left_text_right(slide, spec: dict[str, Any], base_dir: Path, s
 
 
 
+def _render_extended(slide, spec: dict[str, Any], styles, archetype_spec: dict[str, Any], archetype_id: str) -> None:
+    """MVP renderer for v1.1 extended archetypes.
+
+    This implementation is intentionally placeholder-driven and template-mapping-driven.
+    It treats the template spec slot mappings as the source of truth.
+
+    Conventions (per docs/design/v1.1-archetype-library-and-hints.md):
+    - Columns: col1_body..colN_body
+    - Pillars: pillar1_body..pillarN_body
+    - Table: table_text
+    - Table+desc: table_text + body
+    - Timeline: milestone1_body..milestoneN_body (N best-effort)
+    """
+
+    title = spec.get("title", "")
+    _set_placeholder_text(
+        slide,
+        _slot_index(archetype_spec, "title", 0),
+        title,
+        styles.get("title"),
+        context=f"archetype={archetype_id} slot=title",
+    )
+
+    def set_text_slot(slot_name: str, value: str | None, style_key: str = "body"):
+        _set_placeholder_text(
+            slide,
+            _slot_index(archetype_spec, slot_name),
+            value,
+            styles.get(style_key),
+            context=f"archetype={archetype_id} slot={slot_name}",
+        )
+
+    if archetype_id in {"two_col", "three_col", "four_col"}:
+        n = {"two_col": 2, "three_col": 3, "four_col": 4}[archetype_id]
+        for i in range(1, n + 1):
+            set_text_slot(f"col{i}_body", spec.get(f"col{i}_body"))
+        return
+
+    if archetype_id in {"pillars_3", "pillars_4"}:
+        n = 3 if archetype_id == "pillars_3" else 4
+        for i in range(1, n + 1):
+            set_text_slot(f"pillar{i}_body", spec.get(f"pillar{i}_body"))
+        return
+
+    if archetype_id == "table":
+        # MVP: treat table content as text.
+        set_text_slot("table_text", spec.get("table_text"), style_key="body")
+        return
+
+    if archetype_id == "table_plus_description":
+        set_text_slot("table_text", spec.get("table_text"), style_key="body")
+        # Use body slot for description.
+        set_text_slot("body", spec.get("body"), style_key="body")
+        return
+
+    if archetype_id == "timeline_horizontal":
+        # Best-effort: fill milestone{i}_body for i=1..10.
+        for i in range(1, 11):
+            k = f"milestone{i}_body"
+            if k in spec:
+                set_text_slot(k, spec.get(k))
+        return
+
+    raise RenderingError(f"Extended archetype '{archetype_id}' is not implemented")
+
+
+
 def _set_notes(slide, notes: str | None) -> None:
     if not notes:
         return
@@ -251,6 +318,8 @@ def render_deck(
             _render_title_and_bullets(slide, slide_spec, styles, archetype_spec, archetype)
         elif archetype == "image_left_text_right":
             _render_image_left_text_right(slide, slide_spec, source_dir, styles, archetype_spec, archetype)
+        elif archetype in {"two_col", "three_col", "four_col", "pillars_3", "pillars_4", "table", "table_plus_description", "timeline_horizontal"}:
+            _render_extended(slide, slide_spec, styles, archetype_spec, archetype)
         else:
             raise RenderingError(f"Archetype '{archetype}' is not implemented")
 

--- a/tests/test_renderer_extended_archetypes_errors.py
+++ b/tests/test_renderer_extended_archetypes_errors.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from slide_smith.renderer import RenderingError, render_deck
+
+
+def test_render_deck_extended_archetype_requires_template_support(tmp_path: Path) -> None:
+    deck_spec = {
+        "title": "Demo",
+        "slides": [
+            {"archetype": "two_col", "title": "Two", "col1_body": "L", "col2_body": "R"},
+        ],
+    }
+
+    # Template spec intentionally does not include two_col.
+    template_spec = {
+        "template_id": "t",
+        "archetypes": [
+            {"id": "title", "layout": "Title Slide", "slots": [{"name": "title", "type": "text", "placeholder_idx": 0}]}
+        ],
+        "styles": {},
+    }
+
+    with pytest.raises(RenderingError) as excinfo:
+        render_deck(deck_spec, template_spec, "default", str(tmp_path / "out.pptx"), base_dir=str(tmp_path))
+
+    assert "not supported" in str(excinfo.value)


### PR DESCRIPTION
Addresses #37 (first slice): adds an MVP renderer for extended archetypes:

- two_col / three_col / four_col
- pillars_3 / pillars_4
- table / table_plus_description (text-based MVP)
- timeline_horizontal (milestone*_body best-effort)

Placeholder-driven via template.json slot mappings.

Includes a basic test asserting unsupported archetypes fail clearly.