### PR TITLE
Code review cleanup: mapper title idx + hints dead code

### DIFF
--- a/src/slide_smith/hints.py
+++ b/src/slide_smith/hints.py
@@ -56,7 +56,6 @@ def apply_hints_to_template_spec(updated_spec: dict[str, Any], hints: dict[str, 
 
     out = dict(updated_spec)
     archetypes = [a for a in (out.get("archetypes") or []) if isinstance(a, dict)]
-    by_id = {a.get("id"): a for a in archetypes if isinstance(a.get("id"), str)}
 
     layouts = hints.get("layouts") if isinstance(hints, dict) else None
     if not isinstance(layouts, dict):

--- a/src/slide_smith/template_mapper_extended.py
+++ b/src/slide_smith/template_mapper_extended.py
@@ -142,7 +142,17 @@ def infer_extended_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
             continue
 
         # Minimal slot set for v1.1 mapping: just bodies; caller can refine with hints/interactive.
-        slots: list[dict[str, Any]] = [{"name": "title", "type": "text", "required": True, "placeholder_idx": (src.get("slots") or [{}])[0].get("placeholder_idx", 0)}]
+        title_idx = None
+        for s in src.get("slots") or []:
+            if isinstance(s, dict) and s.get("name") == "title":
+                if isinstance(s.get("placeholder_idx"), int):
+                    title_idx = int(s.get("placeholder_idx"))
+                break
+
+        title_slot: dict[str, Any] = {"name": "title", "type": "text", "required": True}
+        if title_idx is not None:
+            title_slot["placeholder_idx"] = title_idx
+        slots: list[dict[str, Any]] = [title_slot]
 
         def add_slot(name: str):
             # Choose the next placeholder idx from the source that isn't title.

--- a/tests/test_hints_apply_slot_hints.py
+++ b/tests/test_hints_apply_slot_hints.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from slide_smith.hints import apply_hints_to_template_spec
+
+
+def test_apply_hints_applies_slot_placeholder_idx_by_layout() -> None:
+    spec = {
+        "template_id": "t",
+        "archetypes": [
+            {
+                "id": "two_col",
+                "layout": "L1",
+                "slots": [
+                    {"name": "title", "type": "text", "required": True, "placeholder_idx": 0},
+                    {"name": "col1_body", "type": "text", "required": True, "placeholder_idx": 10},
+                    {"name": "col2_body", "type": "text", "required": True, "placeholder_idx": 11},
+                ],
+            }
+        ],
+    }
+
+    hints = {
+        "hints_version": 1,
+        "layouts": {
+            "L1": {
+                "slot_hints": {
+                    "col1_body": {"placeholder_idx": 20}
+                }
+            }
+        },
+    }
+
+    out = apply_hints_to_template_spec(spec, hints)
+    a = out["archetypes"][0]
+    col1 = [s for s in a["slots"] if s["name"] == "col1_body"][0]
+    assert col1["placeholder_idx"] == 20
+    assert a.get("hinting", {}).get("applied") is True


### PR DESCRIPTION
Addresses:
- #50: fix template_mapper_extended title placeholder_idx selection (find by slot name)
- #51: remove unused by_id in hints.apply_hints_to_template_spec

Also adds a small unit test for slot_hints application.