### PR TITLE
Refactor: template validation split semantic vs structural

### DIFF
--- a/src/slide_smith/template_validator.py
+++ b/src/slide_smith/template_validator.py
@@ -19,106 +19,65 @@ class TemplateValidationError(Exception):
     pass
 
 
-def validate_template(
-    template_id: str,
-    templates_dir: str | None = None,
-    profile: str = "structural",
-) -> TemplateValidationResult:
+def _validate_semantic(archetypes: list[object], profile: str) -> list[str]:
     errors: list[str] = []
 
-    spec = load_template_spec(template_id, templates_dir=templates_dir)
-    tdir = template_dir(template_id, templates_dir=templates_dir)
-    pptx_path = tdir / "template.pptx"
+    if profile not in {"standard", "extended"}:
+        return errors
 
-    if profile not in {"structural", "standard", "extended"}:
-        raise TemplateValidationError(f"Unknown validation profile: {profile}")
+    required: dict[str, dict[str, bool]] = {
+        "title": {"title": True},
+        "section": {"title": True},
+        "title_and_bullets": {"title": True, "bullets": True},
+        "image_left_text_right": {"title": True, "image": True, "body": True},
+    }
 
-    has_pptx = pptx_path.exists()
-
-    # Allow templates that are JSON-only (no pptx) for early-stage prototyping.
-    # For semantic profiles (standard/extended), we still validate the *template.json* expectations even if pptx is missing.
-    if not has_pptx and profile == "structural":
-        return TemplateValidationResult(
-            ok=True,
-            errors=[f"warning: template.pptx not found; skipping layout/placeholder checks: {pptx_path}"],
-        )
-
-    prs = Presentation(str(pptx_path)) if has_pptx else None
-
-    # Layout existence check.
-    layout_names = {layout.name for layout in prs.slide_layouts} if prs is not None else set()
-
-    archetypes = spec.get("archetypes") or []
-    if not isinstance(archetypes, list) or not archetypes:
-        errors.append("template spec must include non-empty 'archetypes' list")
-        return TemplateValidationResult(False, errors)
-
-    if profile in {"standard", "extended"}:
-        # Semantic compatibility checks (in addition to structural ones).
-        required = {
-            # Core standard archetypes.
-            "title": {"title": True},
-            "section": {"title": True},
-            "title_and_bullets": {"title": True, "bullets": True},
-            "image_left_text_right": {"title": True, "image": True, "body": True},
+    if profile == "extended":
+        required |= {
+            "two_col": {"title": True, "col1_body": True, "col2_body": True},
+            "three_col": {"title": True, "col1_body": True, "col2_body": True, "col3_body": True},
+            "four_col": {"title": True, "col1_body": True, "col2_body": True, "col3_body": True, "col4_body": True},
+            "pillars_3": {"title": True, "pillar1_body": True, "pillar2_body": True, "pillar3_body": True},
+            "pillars_4": {"title": True, "pillar1_body": True, "pillar2_body": True, "pillar3_body": True, "pillar4_body": True},
+            "table": {"title": True, "table_text": True},
+            "table_plus_description": {"title": True, "table_text": True, "body": True},
+            "timeline_horizontal": {"title": True, "milestone1_body": True},
         }
 
-        if profile == "extended":
-            # Extended archetypes (v1.1). Slot requirements are intentionally minimal at this layer:
-            # we validate that a mapping exists, not that the renderer fully supports it.
-            required |= {
-                "two_col": {"title": True, "col1_body": True, "col2_body": True},
-                "three_col": {"title": True, "col1_body": True, "col2_body": True, "col3_body": True},
-                "four_col": {
-                    "title": True,
-                    "col1_body": True,
-                    "col2_body": True,
-                    "col3_body": True,
-                    "col4_body": True,
-                },
-                "pillars_3": {"title": True, "pillar1_body": True, "pillar2_body": True, "pillar3_body": True},
-                "pillars_4": {
-                    "title": True,
-                    "pillar1_body": True,
-                    "pillar2_body": True,
-                    "pillar3_body": True,
-                    "pillar4_body": True,
-                },
-                "table": {"title": True, "table_text": True},
-                "table_plus_description": {"title": True, "table_text": True, "body": True},
-                "timeline_horizontal": {"title": True, "milestone1_body": True},
-            }
+    typed_archetypes = [a for a in archetypes if isinstance(a, dict)]
+    by_id = {a.get("id"): a for a in typed_archetypes}
 
-        by_id = {a.get("id"): a for a in archetypes if isinstance(a, dict)}
-        prefix = f"{profile} profile"
-        for aid, req_slots in required.items():
-            if aid not in by_id:
-                errors.append(f"{prefix}: missing required archetype '{aid}'")
+    prefix = f"{profile} profile"
+    for aid, req_slots in required.items():
+        if aid not in by_id:
+            errors.append(f"{prefix}: missing required archetype '{aid}'")
+            continue
+        a = by_id[aid]
+        slots = a.get("slots") or []
+        if not isinstance(slots, list):
+            errors.append(f"{prefix}: archetype '{aid}' slots must be a list")
+            continue
+        slot_by_name = {s.get("name"): s for s in slots if isinstance(s, dict)}
+        for slot_name, must in req_slots.items():
+            if not must:
                 continue
-            a = by_id[aid]
-            slots = a.get("slots") or []
-            if not isinstance(slots, list):
-                errors.append(f"{prefix}: archetype '{aid}' slots must be a list")
+            if slot_name not in slot_by_name:
+                errors.append(f"{prefix}: archetype '{aid}' missing required slot '{slot_name}'")
                 continue
-            slot_by_name = {s.get("name"): s for s in slots if isinstance(s, dict)}
-            for slot_name, must in req_slots.items():
-                if not must:
-                    continue
-                if slot_name not in slot_by_name:
-                    errors.append(f"{prefix}: archetype '{aid}' missing required slot '{slot_name}'")
-                    continue
-                slot = slot_by_name[slot_name]
-                idx = slot.get("placeholder_idx")
-                if not isinstance(idx, int):
-                    errors.append(f"{prefix}: archetype '{aid}' slot '{slot_name}' missing int placeholder_idx")
+            slot = slot_by_name[slot_name]
+            idx = slot.get("placeholder_idx")
+            if not isinstance(idx, int):
+                errors.append(f"{prefix}: archetype '{aid}' slot '{slot_name}' missing int placeholder_idx")
 
-        # If we're already failing semantic requirements, stop early to avoid noisy placeholder checks.
-        if errors:
-            return TemplateValidationResult(False, errors)
+    return errors
+
+
+def _validate_structural(archetypes: list[object], prs: Presentation) -> list[str]:
+    errors: list[str] = []
+
+    layout_names = {layout.name for layout in prs.slide_layouts}
 
     def layout_by_name(name: str):
-        if prs is None:
-            return None
         for layout in prs.slide_layouts:
             if layout.name == name:
                 return layout
@@ -136,20 +95,13 @@ def validate_template(
         if not isinstance(layout_name, str) or not layout_name:
             errors.append(f"archetype '{aid}' missing required 'layout'")
             continue
-        if prs is not None:
-            if layout_name not in layout_names:
-                errors.append(f"archetype '{aid}': slide layout not found: '{layout_name}'")
-                continue
-
-        layout = layout_by_name(layout_name)
-        if prs is not None and layout is None:
-            # defensive
+        if layout_name not in layout_names:
             errors.append(f"archetype '{aid}': slide layout not found: '{layout_name}'")
             continue
 
-        # Placeholder indices exist check.
-        # Only possible when pptx is present.
+        layout = layout_by_name(layout_name)
         if layout is None:
+            errors.append(f"archetype '{aid}': slide layout not found: '{layout_name}'")
             continue
 
         for slot in a.get("slots") or []:
@@ -174,5 +126,43 @@ def validate_template(
                 errors.append(
                     f"archetype '{aid}': layout '{layout_name}' missing placeholder idx={idx} for slot '{slot.get('name','?')}'"
                 )
+
+    return errors
+
+
+def validate_template(
+    template_id: str,
+    templates_dir: str | None = None,
+    profile: str = "structural",
+) -> TemplateValidationResult:
+    errors: list[str] = []
+
+    spec = load_template_spec(template_id, templates_dir=templates_dir)
+    tdir = template_dir(template_id, templates_dir=templates_dir)
+    pptx_path = tdir / "template.pptx"
+
+    if profile not in {"structural", "standard", "extended"}:
+        raise TemplateValidationError(f"Unknown validation profile: {profile}")
+
+    archetypes = spec.get("archetypes") or []
+    if not isinstance(archetypes, list) or not archetypes:
+        return TemplateValidationResult(False, ["template spec must include non-empty 'archetypes' list"])
+
+    # Semantic checks can run without a pptx.
+    if profile in {"standard", "extended"}:
+        errors.extend(_validate_semantic(archetypes, profile))
+        if errors:
+            return TemplateValidationResult(False, errors)
+
+    has_pptx = pptx_path.exists()
+    if not has_pptx and profile == "structural":
+        return TemplateValidationResult(
+            ok=True,
+            errors=[f"warning: template.pptx not found; skipping layout/placeholder checks: {pptx_path}"],
+        )
+
+    if has_pptx:
+        prs = Presentation(str(pptx_path))
+        errors.extend(_validate_structural(archetypes, prs))
 
     return TemplateValidationResult(ok=(len(errors) == 0), errors=errors)


### PR DESCRIPTION
Addresses #53: refactors template_validator.validate_template to split semantic validation (standard/extended) from structural pptx validation.

No behavior change intended; semantic profiles still validate JSON-only templates.