### PR TITLE
feat: template-native archetypes + native_preferred

### DIFF
--- a/docs/design/template-model.md
+++ b/docs/design/template-model.md
@@ -1,5 +1,7 @@
 # Template Storage and Representation Model
 
+> v2 note: templates may optionally define **template-native archetypes** (namespaced) in addition to the global core archetype set, and can map core → native via `deck.native_preferred`. See: `docs/design/archetypes-v2.md`.
+
 ## Decision
 
 `slide_smith` should use a **dual-artifact template model**:

--- a/src/slide_smith/commands/inspect_template.py
+++ b/src/slide_smith/commands/inspect_template.py
@@ -12,25 +12,40 @@ def handle_inspect_template(*, template: str, templates_dir: str | None) -> tupl
     deck = spec.get("deck", {})
     lines.append(f"aspect_ratio: {deck.get('aspect_ratio', 'unknown')}")
 
+    native_pref = deck.get("native_preferred")
+    if isinstance(native_pref, dict) and native_pref:
+        lines.append("native_preferred:")
+        for k, v in native_pref.items():
+            lines.append(f"- {k} -> {v}")
+
     if spec.get("styles"):
         lines.append("styles:")
         for k, v in (spec.get("styles") or {}).items():
             lines.append(f"- {k}: {v}")
 
-    lines.append("supported_archetypes:")
-    for archetype in spec.get("archetypes", []):
-        lines.append(f"- {archetype['id']}: {archetype.get('description', '')}")
-        lines.append(f"  layout: {archetype.get('layout', 'unknown')}")
-        for slot in archetype.get("slots", []):
-            required = "required" if slot.get("required") else "optional"
-            extras = []
-            if "placeholder_idx" in slot:
-                extras.append(f"placeholder_idx={slot['placeholder_idx']}")
-            if "max_items" in slot:
-                extras.append(f"max_items={slot['max_items']}")
-            if "aspect_ratio" in slot:
-                extras.append(f"aspect_ratio={slot['aspect_ratio']}")
-            extra_text = f" ({', '.join(extras)})" if extras else ""
-            lines.append(f"  - slot {slot['name']}: {slot['type']} [{required}]{extra_text}")
+    def dump_archetypes(header: str, archetypes: list[object]) -> None:
+        lines.append(header)
+        for archetype in archetypes:
+            if not isinstance(archetype, dict):
+                continue
+            lines.append(f"- {archetype['id']}: {archetype.get('description', '')}")
+            lines.append(f"  layout: {archetype.get('layout', 'unknown')}")
+            for slot in archetype.get("slots", []):
+                required = "required" if slot.get("required") else "optional"
+                extras = []
+                if "placeholder_idx" in slot:
+                    extras.append(f"placeholder_idx={slot['placeholder_idx']}")
+                if "max_items" in slot:
+                    extras.append(f"max_items={slot['max_items']}")
+                if "aspect_ratio" in slot:
+                    extras.append(f"aspect_ratio={slot['aspect_ratio']}")
+                extra_text = f" ({', '.join(extras)})" if extras else ""
+                lines.append(f"  - slot {slot['name']}: {slot['type']} [{required}]{extra_text}")
+
+    dump_archetypes("archetypes:", list(spec.get("archetypes", []) or []))
+
+    native = spec.get("native")
+    if isinstance(native, dict) and native.get("archetypes"):
+        dump_archetypes("native_archetypes:", list(native.get("archetypes") or []))
 
     return 0, "\n".join(lines)

--- a/src/slide_smith/renderer.py
+++ b/src/slide_smith/renderer.py
@@ -508,13 +508,34 @@ def render_deck(
     slide_h_emu = int(prs.slide_height)
 
     styles = load_styles(template_spec)
-    archetypes = {item["id"]: item for item in template_spec.get("archetypes", [])}
+    archetypes = {item["id"]: item for item in template_spec.get("archetypes", []) if isinstance(item, dict) and isinstance(item.get("id"), str)}
+
+    deck_meta = template_spec.get("deck") or {}
+    native_pref = deck_meta.get("native_preferred") or {}
+
+    def resolve_template_archetype_id(slide_archetype_id: str) -> str:
+        """Resolve the template archetype to use for a given slide archetype.
+
+        Allows templates to define a preferred template-native archetype for a core archetype.
+        The slide archetype (and therefore renderer code path) remains the slide's archetype;
+        only the *template mapping* (layout + slot placeholder indices/boxes) can be swapped.
+        """
+
+        if isinstance(native_pref, dict):
+            preferred = native_pref.get(slide_archetype_id)
+            if isinstance(preferred, str) and preferred in archetypes:
+                return preferred
+        return slide_archetype_id
 
     for slide_spec in deck_spec.get("slides", []):
         archetype = slide_spec["archetype"]
-        if archetype not in archetypes:
-            raise RenderingError(f"Archetype '{archetype}' not supported by template '{template_id}'")
-        archetype_spec = archetypes[archetype]
+        template_archetype_id = resolve_template_archetype_id(archetype)
+        if template_archetype_id not in archetypes:
+            raise RenderingError(
+                f"Archetype '{archetype}' not supported by template '{template_id}'"
+                + (" (native_preferred mapping pointed to missing archetype)" if template_archetype_id != archetype else "")
+            )
+        archetype_spec = archetypes[template_archetype_id]
         slide = prs.slides.add_slide(_layout_for_archetype(prs, archetype_spec))
 
         if archetype == "title":

--- a/src/slide_smith/template_validator.py
+++ b/src/slide_smith/template_validator.py
@@ -219,10 +219,45 @@ def validate_template(
     if not isinstance(archetypes, list) or not archetypes:
         return TemplateValidationResult(False, ["template spec must include non-empty 'archetypes' list"])
 
+    # Template-native archetypes (optional). These are additional archetype definitions that
+    # may be referenced directly by callers (namespaced IDs recommended), or used via
+    # deck.native_preferred to select a richer layout while keeping a core slide archetype.
+    native = spec.get("native") or {}
+    native_archetypes = []
+    if isinstance(native, dict):
+        native_archetypes = native.get("archetypes") or []
+
+    if native_archetypes and not isinstance(native_archetypes, list):
+        return TemplateValidationResult(False, ["template spec 'native.archetypes' must be a list when present"])
+
+    # Validate native_preferred mapping integrity (only when present).
+    deck = spec.get("deck") or {}
+    native_pref = deck.get("native_preferred")
+    if native_pref is not None and not isinstance(native_pref, dict):
+        return TemplateValidationResult(False, ["template spec 'deck.native_preferred' must be an object when present"])
+
     # Semantic checks can run without a pptx.
     if profile in {"standard", "extended"}:
         errors.extend(_validate_semantic(archetypes, profile))
         if errors:
+            return TemplateValidationResult(False, errors)
+
+    # Validate deck.native_preferred references.
+    if isinstance(native_pref, dict):
+        typed_core = [a for a in archetypes if isinstance(a, dict) and isinstance(a.get("id"), str)]
+        typed_native = [a for a in native_archetypes if isinstance(a, dict) and isinstance(a.get("id"), str)]
+        core_ids = {a["id"] for a in typed_core}
+        native_ids = {a["id"] for a in typed_native}
+        for core_id, preferred_id in native_pref.items():
+            if not isinstance(core_id, str) or not isinstance(preferred_id, str):
+                errors.append("deck.native_preferred: keys/values must be strings")
+                continue
+            if core_id not in core_ids:
+                errors.append(f"deck.native_preferred: unknown core archetype id '{core_id}'")
+            if preferred_id not in (core_ids | native_ids):
+                errors.append(f"deck.native_preferred: preferred archetype id '{preferred_id}' not found in archetypes/native.archetypes")
+
+        if errors and profile in {"standard", "extended"}:
             return TemplateValidationResult(False, errors)
 
     has_pptx = pptx_path.exists()
@@ -235,6 +270,8 @@ def validate_template(
     if has_pptx:
         prs = Presentation(str(pptx_path))
         errors.extend(_validate_structural(archetypes, prs, pptx_path=str(pptx_path)))
+        if native_archetypes:
+            errors.extend(_validate_structural(native_archetypes, prs, pptx_path=str(pptx_path)))
 
     fatal = [e for e in errors if not str(e).startswith("warning:")]
     return TemplateValidationResult(ok=(len(fatal) == 0), errors=errors)

--- a/templates/default/template.json
+++ b/templates/default/template.json
@@ -17,6 +17,9 @@
     "body": {"font": "Calibri", "size_pt": 18, "color_hex": "222222", "line_spacing_pt": 22},
     "bullets": {"font": "Calibri", "size_pt": 18, "color_hex": "222222", "line_spacing_pt": 22}
   },
+  "native": {
+    "archetypes": []
+  },
   "archetypes": [
     {
       "id": "title",


### PR DESCRIPTION
Fixes #82

Adds an explicit template-native archetype layer:
- `template.json` may now include `native: { archetypes: [...] }` (same archetype object shape; namespaced IDs recommended)
- `validate-template` now validates `native.archetypes` structurally (layout/placeholder checks) and validates `deck.native_preferred` references when present
- `inspect-template` prints `native_preferred` and a separate `native_archetypes:` section

Also adds an initial renderer hook:
- templates may optionally define `deck.native_preferred: { core_id: preferred_template_archetype_id }`
- renderer keeps the *slide archetype* for logic/slot semantics, but uses the preferred template archetype mapping for layout/slot targets when available

Docs:
- `docs/design/template-model.md` now mentions template-native archetypes and `deck.native_preferred`.

Notes:
- This is intentionally minimal: it enables richer layouts without expanding the global core registry.
- We can iterate on schema formalization and mapping UX in follow-ups.
