### PR TITLE
fix: tighten timeline_horizontal schema

### DIFF
--- a/docs/design/deck-spec.schema.json
+++ b/docs/design/deck-spec.schema.json
@@ -218,9 +218,8 @@
       "allOf": [
         { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "timeline_horizontal" } },
-          "required": ["archetype", "title"],
           "properties": {
+            "archetype": { "const": "timeline_horizontal" },
             "milestone1_body": { "type": "string" },
             "milestone2_body": { "type": "string" },
             "milestone3_body": { "type": "string" },
@@ -231,7 +230,8 @@
             "milestone8_body": { "type": "string" },
             "milestone9_body": { "type": "string" },
             "milestone10_body": { "type": "string" }
-          }
+          },
+          "required": ["archetype", "title", "milestone1_body"]
         }
       ]
     }


### PR DESCRIPTION
## Summary

Fix JSON Schema for timeline_horizontal_slide so it no longer overlaps other archetypes during oneOf validation.

## What changed

- Removed duplicate properties key that caused the archetype const to be overwritten.
- Ensured archetype is exactly timeline_horizontal.
- Required milestone1_body so the timeline schema only matches timeline slides.

## Expected

Deck specs using title / title_and_bullets / image_left_text_right should validate unambiguously and slide-smith create should proceed.

Fixes ninjapapa/slide_smith#93
