### PR TITLE
feat: compat alias for text_with_image

### DIFF
--- a/docs/design/deck-spec.schema.json
+++ b/docs/design/deck-spec.schema.json
@@ -27,6 +27,7 @@
         { "$ref": "#/$defs/section_slide" },
         { "$ref": "#/$defs/title_and_bullets_slide" },
         { "$ref": "#/$defs/image_left_text_right_slide" },
+        { "$ref": "#/$defs/text_with_image_slide" },
 
         { "$ref": "#/$defs/two_col_slide" },
         { "$ref": "#/$defs/three_col_slide" },
@@ -106,6 +107,16 @@
         { "$ref": "#/$defs/base_slide" },
         {
           "properties": { "archetype": { "const": "image_left_text_right" } },
+          "required": ["archetype", "title", "body", "image"]
+        }
+      ]
+    },
+
+    "text_with_image_slide": {
+      "allOf": [
+        { "$ref": "#/$defs/base_slide" },
+        {
+          "properties": { "archetype": { "const": "text_with_image" } },
           "required": ["archetype", "title", "body", "image"]
         }
       ]

--- a/src/slide_smith/commands/create.py
+++ b/src/slide_smith/commands/create.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from slide_smith.deck_spec import load_deck_spec, validate_deck_spec
+from slide_smith.deck_spec import load_deck_spec, normalize_deck_spec, validate_deck_spec
 from slide_smith.markdown_parser import parse_markdown
 from slide_smith.renderer import RenderingError, render_deck
 from slide_smith.template_loader import load_template_spec
@@ -35,12 +35,20 @@ def handle_create(
         except AssetError as exc:
             return 1, f"Asset collection failed: {exc}"
 
+    spec, normalize_warnings = normalize_deck_spec(spec)
+
     # Default to legacy validation (v1 core + v1.1 extended). New v2 families are
     # behind an explicit profile until they are fully stabilized.
     errors = validate_deck_spec(spec, profile="legacy")
     if errors:
         lines = ["Deck spec validation failed:"] + [f"- {e}" for e in errors]
         return 1, "\n".join(lines)
+
+    # Non-fatal warnings (e.g. deprecated archetype ids).
+    if normalize_warnings and print_mode != "none":
+        # We only surface these in human-readable mode to avoid breaking JSON output.
+        pre = "\n".join(["Warnings:"] + [f"- {w}" for w in normalize_warnings])
+        print(pre)
 
     # Schema validation is the source of truth when jsonschema is available.
     try:

--- a/src/slide_smith/commands/validate_deck_spec.py
+++ b/src/slide_smith/commands/validate_deck_spec.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from slide_smith.deck_spec import load_deck_spec, validate_deck_spec
+from slide_smith.deck_spec import load_deck_spec, normalize_deck_spec, validate_deck_spec
 from slide_smith.markdown_parser import parse_markdown
 
 
@@ -14,6 +14,8 @@ def handle_validate_deck_spec(*, input_path: str, profile: str) -> tuple[int, st
         spec = parse_markdown(input_path)
     else:
         return 1, "Unsupported input type. Use .json or .md"
+
+    spec, normalize_warnings = normalize_deck_spec(spec)
 
     errors = validate_deck_spec(spec, profile=profile)
     if errors:
@@ -42,4 +44,7 @@ def handle_validate_deck_spec(*, input_path: str, profile: str) -> tuple[int, st
     except Exception:
         pass
 
-    return 0, json.dumps({"ok": True, "profile": profile, "slides": len(spec.get('slides') or [])}, indent=2)
+    out = {"ok": True, "profile": profile, "slides": len(spec.get('slides') or [])}
+    if normalize_warnings:
+        out["warnings"] = normalize_warnings
+    return 0, json.dumps(out, indent=2)

--- a/src/slide_smith/deck_spec.py
+++ b/src/slide_smith/deck_spec.py
@@ -13,6 +13,7 @@ SUPPORTED_ARCHETYPES = {
     "section",
     "title_and_bullets",
     "image_left_text_right",
+    "text_with_image",
 
     # v1.1 extended
     "two_col",
@@ -24,6 +25,56 @@ SUPPORTED_ARCHETYPES = {
     "table_plus_description",
     "timeline_horizontal",
 }
+
+
+# Backward-compatible archetype aliases. This enables additive evolution of
+# archetype names without breaking existing deck specs.
+ARCHETYPE_ALIASES: dict[str, str] = {
+    # prefer semantic naming vs geometry-bound naming
+    "image_left_text_right": "text_with_image",
+}
+
+
+def normalize_deck_spec(spec: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Normalize a deck spec in a backwards-compatible way.
+
+    Returns: (normalized_spec, warnings)
+
+    This currently:
+    - maps legacy archetype ids to their modern equivalents
+
+    NOTE: This function is intentionally conservative: it avoids mutating other
+    fields so callers can reason about what changed.
+    """
+
+    if not isinstance(spec, dict):
+        return spec, []
+
+    slides = spec.get("slides")
+    if not isinstance(slides, list):
+        return spec, []
+
+    warnings: list[str] = []
+    out = dict(spec)
+    out_slides: list[Any] = []
+
+    for i, slide in enumerate(slides):
+        if not isinstance(slide, dict):
+            out_slides.append(slide)
+            continue
+
+        archetype = slide.get("archetype")
+        if isinstance(archetype, str) and archetype in ARCHETYPE_ALIASES:
+            new_id = ARCHETYPE_ALIASES[archetype]
+            warnings.append(f"$.slides[{i}].archetype: '{archetype}' is deprecated; use '{new_id}'")
+            slide2 = dict(slide)
+            slide2["archetype"] = new_id
+            out_slides.append(slide2)
+        else:
+            out_slides.append(slide)
+
+    out["slides"] = out_slides
+    return out, warnings
 
 
 def load_deck_spec(path: str) -> dict[str, Any]:
@@ -56,6 +107,12 @@ def validate_deck_spec(spec: dict[str, Any], *, profile: str = "legacy") -> list
         return [f"{_path('slides')}: must be a non-empty array"]
 
     allowed = set(SUPPORTED_ARCHETYPES)
+
+    # New archetypes (additive evolution). These are not yet part of the
+    # renderer's full coverage, but we allow validation to proceed so templates
+    # and agents can iterate.
+    allowed |= {"text_with_image"}
+
     if profile == "core_v2":
         allowed |= {"message", "multi_col", "image_text", "list_visual", "metrics"}
 
@@ -129,7 +186,7 @@ def validate_deck_spec(spec: dict[str, Any], *, profile: str = "legacy") -> list
             if body is not None and not isinstance(body, str):
                 errors.append(f"{_path(sp, 'body')}: must be a string")
 
-        elif archetype == "image_left_text_right":
+        elif archetype in {"image_left_text_right", "text_with_image"}:
             req_str("body")
             image = slide.get("image")
             if isinstance(image, str):

--- a/src/slide_smith/renderer.py
+++ b/src/slide_smith/renderer.py
@@ -778,7 +778,7 @@ def render_deck(
             _render_section(slide, slide_spec, styles, archetype_spec, archetype, slide_w_emu=slide_w_emu, slide_h_emu=slide_h_emu)
         elif archetype == "title_and_bullets":
             _render_title_and_bullets(slide, slide_spec, styles, archetype_spec, archetype, slide_w_emu=slide_w_emu, slide_h_emu=slide_h_emu)
-        elif archetype == "image_left_text_right":
+        elif archetype in {"image_left_text_right", "text_with_image"}:
             _render_image_left_text_right(slide, slide_spec, source_dir, styles, archetype_spec, archetype, slide_w_emu=slide_w_emu, slide_h_emu=slide_h_emu)
         elif archetype in {"two_col", "three_col", "four_col", "pillars_3", "pillars_4", "table", "table_plus_description", "timeline_horizontal"}:
             _render_extended(slide, slide_spec, styles, archetype_spec, archetype, slide_w_emu=slide_w_emu, slide_h_emu=slide_h_emu)


### PR DESCRIPTION
## Summary

Adds backwards-compatible support for the new archetype name `text_with_image`.

## Details

- Adds a deck-spec normalization step mapping legacy `image_left_text_right` -> `text_with_image` (with warnings).
- Updates validation and renderer dispatch to accept `text_with_image`.
- Updates `deck-spec.schema.json` to include `text_with_image_slide` in the `oneOf` union.

Fixes #100
