### PR TITLE
schema: add new base/extended archetypes (issue #99)

### DIFF
--- a/docs/design/deck-spec.schema.json
+++ b/docs/design/deck-spec.schema.json
@@ -26,6 +26,7 @@
         { "$ref": "#/$defs/title_slide" },
         { "$ref": "#/$defs/section_slide" },
         { "$ref": "#/$defs/title_and_bullets_slide" },
+        { "$ref": "#/$defs/title_subtitle_and_bullets_slide" },
         { "$ref": "#/$defs/image_left_text_right_slide" },
         { "$ref": "#/$defs/text_with_image_slide" },
 
@@ -36,7 +37,32 @@
         { "$ref": "#/$defs/pillars_4_slide" },
         { "$ref": "#/$defs/table_slide" },
         { "$ref": "#/$defs/table_plus_description_slide" },
-        { "$ref": "#/$defs/timeline_horizontal_slide" }
+        { "$ref": "#/$defs/timeline_horizontal_slide" },
+
+        { "$ref": "#/$defs/title_subtitle_slide" },
+        { "$ref": "#/$defs/version_page_slide" },
+        { "$ref": "#/$defs/agenda_with_image_slide" },
+        { "$ref": "#/$defs/two_col_with_subtitle_slide" },
+        { "$ref": "#/$defs/three_col_with_subtitle_slide" },
+        { "$ref": "#/$defs/three_col_with_icons_slide" },
+        { "$ref": "#/$defs/five_col_with_icons_slide" },
+        { "$ref": "#/$defs/picture_compare_slide" },
+        { "$ref": "#/$defs/title_only_freeform_slide" }
+      ]
+    },
+
+    "image": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["path"],
+          "properties": {
+            "path": { "type": "string" },
+            "alt": { "type": "string" }
+          }
+        }
       ]
     },
 
@@ -50,21 +76,33 @@
         "subtitle": { "type": "string" },
         "body": { "type": "string" },
         "bullets": { "type": "array", "items": { "type": "string" } },
-        "image": {
-          "oneOf": [
-            { "type": "string" },
-            {
-              "type": "object",
-              "additionalProperties": false,
-              "required": ["path"],
-              "properties": {
-                "path": { "type": "string" },
-                "alt": { "type": "string" }
-              }
-            }
-          ]
-        },
-        "notes": { "type": "string" }
+        "image": { "$ref": "#/$defs/image" },
+        "notes": { "type": "string" },
+
+        "table_text": { "type": "string" },
+        "col1_body": { "type": "string" },
+        "col2_body": { "type": "string" },
+        "col3_body": { "type": "string" },
+        "col4_body": { "type": "string" },
+        "pillar1_body": { "type": "string" },
+        "pillar2_body": { "type": "string" },
+        "pillar3_body": { "type": "string" },
+        "pillar4_body": { "type": "string" },
+
+        "milestone1_body": { "type": "string" },
+        "milestone2_body": { "type": "string" },
+        "milestone3_body": { "type": "string" },
+        "milestone4_body": { "type": "string" },
+        "milestone5_body": { "type": "string" },
+        "milestone6_body": { "type": "string" },
+        "milestone7_body": { "type": "string" },
+        "milestone8_body": { "type": "string" },
+        "milestone9_body": { "type": "string" },
+        "milestone10_body": { "type": "string" },
+
+        "items": { "type": "array" },
+        "left": { "type": "object" },
+        "right": { "type": "object" }
       }
     },
 
@@ -94,10 +132,18 @@
         {
           "properties": { "archetype": { "const": "title_and_bullets" } },
           "required": ["archetype", "title"],
-          "anyOf": [
-            { "required": ["bullets"] },
-            { "required": ["body"] }
-          ]
+          "anyOf": [{ "required": ["bullets"] }, { "required": ["body"] }]
+        }
+      ]
+    },
+
+    "title_subtitle_and_bullets_slide": {
+      "allOf": [
+        { "$ref": "#/$defs/base_slide" },
+        {
+          "properties": { "archetype": { "const": "title_subtitle_and_bullets" } },
+          "required": ["archetype", "title", "subtitle"],
+          "anyOf": [{ "required": ["bullets"] }, { "required": ["body"] }]
         }
       ]
     },
@@ -243,6 +289,189 @@
             "milestone10_body": { "type": "string" }
           },
           "required": ["archetype", "title", "milestone1_body"]
+        }
+      ]
+    },
+
+    "title_subtitle_slide": {
+      "allOf": [
+        { "$ref": "#/$defs/base_slide" },
+        {
+          "properties": { "archetype": { "const": "title_subtitle" } },
+          "required": ["archetype", "title", "subtitle"]
+        }
+      ]
+    },
+
+    "version_page_slide": {
+      "allOf": [
+        { "$ref": "#/$defs/base_slide" },
+        {
+          "properties": { "archetype": { "const": "version_page" } },
+          "required": ["archetype", "title", "table_text"],
+          "properties": {
+            "table_text": { "type": "string" }
+          }
+        }
+      ]
+    },
+
+    "agenda_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["body"],
+      "properties": {
+        "marker": { "type": "string" },
+        "body": { "type": "string" }
+      }
+    },
+
+    "agenda_with_image_slide": {
+      "allOf": [
+        { "$ref": "#/$defs/base_slide" },
+        {
+          "properties": {
+            "archetype": { "const": "agenda_with_image" },
+            "image": { "$ref": "#/$defs/image" },
+            "items": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/agenda_item" }
+            }
+          },
+          "required": ["archetype", "title", "image", "items"]
+        }
+      ]
+    },
+
+    "two_col_with_subtitle_slide": {
+      "allOf": [
+        { "$ref": "#/$defs/base_slide" },
+        {
+          "properties": { "archetype": { "const": "two_col_with_subtitle" } },
+          "required": ["archetype", "title", "subtitle", "col1_body", "col2_body"],
+          "properties": {
+            "col1_body": { "type": "string" },
+            "col2_body": { "type": "string" }
+          }
+        }
+      ]
+    },
+
+    "three_col_text_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["body"],
+      "properties": {
+        "title": { "type": "string" },
+        "body": { "type": "string" }
+      }
+    },
+
+    "three_col_with_subtitle_slide": {
+      "allOf": [
+        { "$ref": "#/$defs/base_slide" },
+        {
+          "properties": {
+            "archetype": { "const": "three_col_with_subtitle" },
+            "items": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/three_col_text_item" }
+            }
+          },
+          "required": ["archetype", "title", "subtitle", "items"]
+        }
+      ]
+    },
+
+    "icon_col_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "body", "icon"],
+      "properties": {
+        "title": { "type": "string" },
+        "body": { "type": "string" },
+        "caption": { "type": "string" },
+        "icon": { "$ref": "#/$defs/image" }
+      }
+    },
+
+    "three_col_with_icons_slide": {
+      "allOf": [
+        { "$ref": "#/$defs/base_slide" },
+        {
+          "properties": {
+            "archetype": { "const": "three_col_with_icons" },
+            "items": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/icon_col_item" }
+            }
+          },
+          "required": ["archetype", "title", "items"]
+        }
+      ]
+    },
+
+    "five_col_icon_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["icon", "body"],
+      "properties": {
+        "body": { "type": "string" },
+        "icon": { "$ref": "#/$defs/image" }
+      }
+    },
+
+    "five_col_with_icons_slide": {
+      "allOf": [
+        { "$ref": "#/$defs/base_slide" },
+        {
+          "properties": {
+            "archetype": { "const": "five_col_with_icons" },
+            "items": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/five_col_icon_item" }
+            }
+          },
+          "required": ["archetype", "title", "items"]
+        }
+      ]
+    },
+
+    "picture_compare_side": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["image"],
+      "properties": {
+        "image": { "$ref": "#/$defs/image" },
+        "title": { "type": "string" },
+        "body": { "type": "string" }
+      }
+    },
+
+    "picture_compare_slide": {
+      "allOf": [
+        { "$ref": "#/$defs/base_slide" },
+        {
+          "properties": {
+            "archetype": { "const": "picture_compare" },
+            "left": { "$ref": "#/$defs/picture_compare_side" },
+            "right": { "$ref": "#/$defs/picture_compare_side" }
+          },
+          "required": ["archetype", "title", "left", "right"]
+        }
+      ]
+    },
+
+    "title_only_freeform_slide": {
+      "allOf": [
+        { "$ref": "#/$defs/base_slide" },
+        {
+          "properties": { "archetype": { "const": "title_only_freeform" } },
+          "required": ["archetype", "title"]
         }
       ]
     }


### PR DESCRIPTION
## Summary

Extends the published deck spec JSON Schema to include the new Base/Extended archetypes from the redesign proposal.

## What changed

- `docs/design/deck-spec.schema.json`
  - Adds new archetype slide defs:
    - Base: `title_subtitle_and_bullets`, `text_with_image` (+ keeps legacy `image_left_text_right`)
    - Extended: `title_subtitle`, `version_page`, `agenda_with_image`, `two_col_with_subtitle`, `three_col_with_subtitle`, `three_col_with_icons`, `five_col_with_icons`, `picture_compare`, `title_only_freeform`
  - Adds reusable defs for `image` and item shapes.
- `src/slide_smith/deck_spec.py`
  - Lightweight validator recognizes these archetypes and checks basic required fields.

Fixes #99
