### PR TITLE
feat: template mapper supports redesigned archetypes (issue #102)

### DIFF
--- a/src/slide_smith/template_mapper.py
+++ b/src/slide_smith/template_mapper.py
@@ -33,6 +33,22 @@ STANDARD_ARCHETYPES: dict[str, dict[str, Any]] = {
             {"name": "bullets", "type": "bullet_list", "required": True},
         ]
     },
+    "title_subtitle_and_bullets": {
+        "required_slots": [
+            {"name": "title", "type": "text", "required": True},
+            {"name": "subtitle", "type": "text", "required": True},
+            {"name": "bullets", "type": "bullet_list", "required": True},
+        ]
+    },
+    "text_with_image": {
+        "required_slots": [
+            {"name": "title", "type": "text", "required": True},
+            {"name": "image", "type": "image", "required": True},
+            {"name": "body", "type": "text", "required": True},
+        ]
+    },
+
+    # legacy standard archetype id (kept for backwards compatibility)
     "image_left_text_right": {
         "required_slots": [
             {"name": "title", "type": "text", "required": True},
@@ -151,10 +167,24 @@ def infer_standard_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
         score = 7 + 2 * min(c["image"], 1) + 1 * min(c["body"], 1) + 1 * min(c["bullets"], 1)
         return float(score), f"title={c['title']} image={c['image']} body={c['body']} bullets={c['bullets']}"
 
+    def score_title_subtitle_and_bullets(a: dict[str, Any]):
+        c = _slot_counts(a)
+        if c["title"] < 1:
+            return 0.0, "missing title slot"
+        if c["subtitle"] < 1:
+            return 0.0, "missing subtitle slot"
+        if c["bullets"] < 1 and c["body"] < 1:
+            return 0.0, "missing bullets/body slot"
+        score = 7 + 2 * min(c["bullets"], 1) + 1 * min(c["body"], 1) + 2 * min(c["subtitle"], 1) - 3 * c["image"]
+        return float(score), f"title={c['title']} subtitle={c['subtitle']} bullets={c['bullets']} body={c['body']} image={c['image']}"
+
     picks: dict[str, InferenceCandidate | None] = {
         "title": _pick_best(archetypes, score_title),
         "section": _pick_best(archetypes, score_section),
         "title_and_bullets": _pick_best(archetypes, score_title_and_bullets),
+        "title_subtitle_and_bullets": _pick_best(archetypes, score_title_subtitle_and_bullets),
+        # prefer new semantic name, but keep legacy id supported too.
+        "text_with_image": _pick_best(archetypes, score_image_left_text_right),
         "image_left_text_right": _pick_best(archetypes, score_image_left_text_right),
     }
 
@@ -188,6 +218,8 @@ def infer_standard_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
             # For bullets, bootstrap uses type "bullets".
             if idx is None and name == "bullets":
                 idx = _first_slot_idx(src, want_type="bullets")
+                if idx is None:
+                    idx = _first_slot_idx(src, want_name="body")
             # fallback: accept first text-like slot.
             if idx is None and name in {"subtitle", "body"}:
                 idx = _first_slot_idx(src, want_type="text")

--- a/src/slide_smith/template_mapper_extended.py
+++ b/src/slide_smith/template_mapper_extended.py
@@ -78,12 +78,55 @@ def infer_extended_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
 
         return _score
 
-    # Heuristics are intentionally simple for v1.1.
+    # Heuristics are intentionally simple for v1.1 (and the redesign additions).
     picks = {
         "two_col": pick_best(score_n_cols(2)),
         "three_col": pick_best(score_n_cols(3)),
         "four_col": pick_best(score_n_cols(4)),
     }
+
+    def score_title_subtitle(a: dict[str, Any]):
+        if not _has_title(a):
+            return 0.0, "missing title"
+        # subtitle tends to be another text slot; bootstrap may name it subtitle.
+        subtitles = _count_slot(a, want_name_prefix="subtitle")
+        bodies = _count_slot(a, want_type="bullets") + _count_slot(a, want_name_prefix="body")
+        images = _count_slot(a, want_type="image")
+        # Prefer title+subtitle with few other fields.
+        score = 6.0 + 3.0 * min(subtitles, 1) - 1.0 * bodies - 2.0 * images
+        if subtitles < 1:
+            score -= 4.0
+        return score, f"subtitles={subtitles} bodies={bodies} images={images} idxs={_placeholder_idxs(a)}"
+
+    def score_icons_cols(n: int):
+        def _score(a: dict[str, Any]):
+            if not _has_title(a):
+                return 0.0, "missing title"
+            images = _count_slot(a, want_type="image")
+            bodies = _count_slot(a, want_type="bullets") + _count_slot(a, want_name_prefix="body")
+            # Prefer n images and n bodies.
+            score = 5.0 + 2.0 * min(images, n) + 1.5 * min(bodies, n)
+            if images < n:
+                score -= (n - images) * 4.0
+            return score, f"images={images} bodies={bodies} idxs={_placeholder_idxs(a)}"
+
+        return _score
+
+    def score_picture_compare(a: dict[str, Any]):
+        if not _has_title(a):
+            return 0.0, "missing title"
+        images = _count_slot(a, want_type="image")
+        bodies = _count_slot(a, want_type="bullets") + _count_slot(a, want_name_prefix="body")
+        score = 6.0 + 2.5 * min(images, 2) + 1.0 * min(bodies, 2)
+        if images < 2:
+            score -= 6.0
+        return score, f"images={images} bodies={bodies} idxs={_placeholder_idxs(a)}"
+
+    # Redesign extended archetypes (best-effort inference)
+    picks["title_subtitle"] = pick_best(score_title_subtitle)
+    picks["three_col_with_icons"] = pick_best(score_icons_cols(3))
+    picks["five_col_with_icons"] = pick_best(score_icons_cols(5))
+    picks["picture_compare"] = pick_best(score_picture_compare)
 
     def score_table(a: dict[str, Any]):
         if not _has_title(a):
@@ -182,6 +225,30 @@ def infer_extended_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
             add_slot("body")
         elif ext_id == "timeline_horizontal":
             add_slot("milestone1_body")
+
+        elif ext_id == "title_subtitle":
+            add_slot("subtitle")
+
+        elif ext_id == "three_col_with_icons":
+            # Convention: col{i}_icon + title/body/caption.
+            for i in range(1, 4):
+                slots.append({"name": f"col{i}_icon", "type": "image", "required": True})
+                add_slot(f"col{i}_title")
+                add_slot(f"col{i}_body")
+                slots.append({"name": f"col{i}_caption", "type": "text", "required": False})
+
+        elif ext_id == "five_col_with_icons":
+            for i in range(1, 6):
+                slots.append({"name": f"item{i}_icon", "type": "image", "required": True})
+                add_slot(f"item{i}_body")
+
+        elif ext_id == "picture_compare":
+            slots.append({"name": "left_image", "type": "image", "required": True})
+            slots.append({"name": "right_image", "type": "image", "required": True})
+            add_slot("left_title")
+            add_slot("left_body")
+            add_slot("right_title")
+            add_slot("right_body")
 
         generated.append(
             {


### PR DESCRIPTION
## Summary

Updates template mapping inference to generate mappings for the redesigned archetypes.

## Changes

- Standard mapper now includes new base archetypes:
  - `title_subtitle_and_bullets`
  - `text_with_image` (preferred) + keeps `image_left_text_right` legacy
- Extended mapper adds best-effort inference for:
  - `title_subtitle`
  - `three_col_with_icons`
  - `five_col_with_icons`
  - `picture_compare`

These are heuristic and intended to be reviewed/edited in the generated template spec.

Fixes #102
