### PR TITLE
refine: agenda_with_image item placeholder mapping + slot conventions

### DIFF
--- a/docs/design/archetype-redesign-v1.md
+++ b/docs/design/archetype-redesign-v1.md
@@ -112,6 +112,30 @@ When an archetype receives more items than a layout supports:
 - **Default:** truncate to capacity and add a warning.
 - Optional future enhancement: `params.overflow: "error" | "truncate"`.
 
+## Render-time slot naming conventions (template.json)
+
+Even when deck specs use structured fields (`items[]`, `left/right`), the renderer ultimately targets **template slots**.
+
+Conventions (proposed):
+
+- `agenda_with_image`
+  - `image`
+  - `item{n}_marker` (optional)
+  - `item{n}_body` (required)
+  - If these slots are absent, renderer falls back to `bullets`/`body`.
+
+- `three_col_with_icons`
+  - `col1_icon`, `col1_title`, `col1_body`, `col1_caption?`
+  - `col2_icon`, `col2_title`, `col2_body`, `col2_caption?`
+  - `col3_icon`, `col3_title`, `col3_body`, `col3_caption?`
+
+- `five_col_with_icons`
+  - `item1_icon`, `item1_body` … `item5_icon`, `item5_body`
+
+- `picture_compare`
+  - `left_image`, `left_title?`, `left_body?`
+  - `right_image`, `right_title?`, `right_body?`
+
 ---
 
 # Proposed Archetype Sets

--- a/src/slide_smith/renderer.py
+++ b/src/slide_smith/renderer.py
@@ -813,7 +813,34 @@ def _render_extended(
             slide_h_emu=slide_h_emu,
             context=f"archetype={archetype_id} slot=image",
         )
+
         items = spec.get("items") or []
+
+        # Preferred: map into dedicated placeholders when the template exposes them.
+        # Convention:
+        # - item{n}_marker (optional)
+        # - item{n}_body (required)
+        # If the template doesn't have these slots, we fall back to bullets/body.
+        has_item_slots = _slot_spec(archetype_spec, "item1_body") is not None
+        if has_item_slots and isinstance(items, list):
+            for idx, it in enumerate(items, start=1):
+                if not isinstance(it, dict):
+                    continue
+                marker = it.get("marker")
+                body = it.get("body")
+
+                # If marker is missing, auto-number.
+                if not (isinstance(marker, str) and marker):
+                    marker = str(idx)
+
+                if isinstance(body, str) and body:
+                    # marker slot is optional; only set if it exists.
+                    if _slot_spec(archetype_spec, f"item{idx}_marker") is not None:
+                        set_text_slot(f"item{idx}_marker", str(marker), style_key="body")
+                    set_text_slot(f"item{idx}_body", body, style_key="body")
+            return
+
+        # Fallback: render as bullets/body.
         lines: list[str] = []
         if isinstance(items, list):
             for it in items:


### PR DESCRIPTION
## Summary

Refines the redesigned archetype implementation by:

- Implementing placeholder-based mapping for `agenda_with_image.items[]` when templates expose `item{n}_body` (and optional `item{n}_marker`) slots.
- Documenting render-time slot naming conventions in the redesign design doc.

## Notes

- Backwards compatible: if item slots are absent, renderer falls back to bullets/body behavior.

Closes #115
Helps #116
