### PR TITLE
test: redesign examples schema + no-duplicate-zip create smoke

### DIFF
--- a/tests/test_cli_create.py
+++ b/tests/test_cli_create.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import zipfile
+from collections import Counter
 from pathlib import Path
 
 
@@ -28,6 +30,13 @@ def test_cli_version_smoke() -> None:
     assert res.stdout.strip()  # may be 'unknown' when not installed
 
 
+def _assert_no_duplicate_zip_members(pptx_path: Path) -> None:
+    with zipfile.ZipFile(pptx_path) as z:
+        c = Counter(z.namelist())
+    dups = [(name, n) for name, n in c.items() if n > 1]
+    assert not dups, f"Duplicate zip members found: {dups[:20]}"
+
+
 def test_cli_create_print_none(tmp_path: Path) -> None:
     out = tmp_path / "out.pptx"
     res = run_cli(
@@ -47,3 +56,5 @@ def test_cli_create_print_none(tmp_path: Path) -> None:
     payload = json.loads(res.stdout)
     assert payload["output"].endswith("out.pptx")
     assert "deck" not in payload
+
+    _assert_no_duplicate_zip_members(out)

--- a/tests/test_redesign_examples_schema.py
+++ b/tests/test_redesign_examples_schema.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from slide_smith.schema_validation import validate_against_schema
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_schema_validation_accepts_redesign_base_example() -> None:
+    sample = ROOT / "docs" / "examples" / "redesign" / "base.sample.json"
+    spec = json.loads(sample.read_text())
+    res = validate_against_schema(spec)
+    assert res.ok, res.errors
+
+
+def test_schema_validation_accepts_redesign_extended_example() -> None:
+    sample = ROOT / "docs" / "examples" / "redesign" / "extended.sample.json"
+    spec = json.loads(sample.read_text())
+    res = validate_against_schema(spec)
+    assert res.ok, res.errors


### PR DESCRIPTION
## Summary

Adds test coverage for redesigned archetypes:

- schema validation accepts the redesign example specs
- create smoke test asserts output PPTX has **no duplicate zip members**

Closes #117
Closes #118
