### PR TITLE
schema: tighten slide validation with unevaluatedProperties (issue #119)

### DIFF
--- a/docs/design/deck-spec.schema.json
+++ b/docs/design/deck-spec.schema.json
@@ -4,7 +4,9 @@
   "title": "slide_smith deck spec",
   "type": "object",
   "additionalProperties": false,
-  "required": ["slides"],
+  "required": [
+    "slides"
+  ],
   "properties": {
     "title": {
       "type": "string"
@@ -23,455 +25,878 @@
   "$defs": {
     "slide": {
       "oneOf": [
-        { "$ref": "#/$defs/title_slide" },
-        { "$ref": "#/$defs/section_slide" },
-        { "$ref": "#/$defs/title_and_bullets_slide" },
-        { "$ref": "#/$defs/title_subtitle_and_bullets_slide" },
-        { "$ref": "#/$defs/image_left_text_right_slide" },
-        { "$ref": "#/$defs/text_with_image_slide" },
-
-        { "$ref": "#/$defs/two_col_slide" },
-        { "$ref": "#/$defs/three_col_slide" },
-        { "$ref": "#/$defs/four_col_slide" },
-        { "$ref": "#/$defs/pillars_3_slide" },
-        { "$ref": "#/$defs/pillars_4_slide" },
-        { "$ref": "#/$defs/table_slide" },
-        { "$ref": "#/$defs/table_plus_description_slide" },
-        { "$ref": "#/$defs/timeline_horizontal_slide" },
-
-        { "$ref": "#/$defs/title_subtitle_slide" },
-        { "$ref": "#/$defs/version_page_slide" },
-        { "$ref": "#/$defs/agenda_with_image_slide" },
-        { "$ref": "#/$defs/two_col_with_subtitle_slide" },
-        { "$ref": "#/$defs/three_col_with_subtitle_slide" },
-        { "$ref": "#/$defs/three_col_with_icons_slide" },
-        { "$ref": "#/$defs/five_col_with_icons_slide" },
-        { "$ref": "#/$defs/picture_compare_slide" },
-        { "$ref": "#/$defs/title_only_freeform_slide" }
+        {
+          "$ref": "#/$defs/title_slide"
+        },
+        {
+          "$ref": "#/$defs/section_slide"
+        },
+        {
+          "$ref": "#/$defs/title_and_bullets_slide"
+        },
+        {
+          "$ref": "#/$defs/title_subtitle_and_bullets_slide"
+        },
+        {
+          "$ref": "#/$defs/image_left_text_right_slide"
+        },
+        {
+          "$ref": "#/$defs/text_with_image_slide"
+        },
+        {
+          "$ref": "#/$defs/two_col_slide"
+        },
+        {
+          "$ref": "#/$defs/three_col_slide"
+        },
+        {
+          "$ref": "#/$defs/four_col_slide"
+        },
+        {
+          "$ref": "#/$defs/pillars_3_slide"
+        },
+        {
+          "$ref": "#/$defs/pillars_4_slide"
+        },
+        {
+          "$ref": "#/$defs/table_slide"
+        },
+        {
+          "$ref": "#/$defs/table_plus_description_slide"
+        },
+        {
+          "$ref": "#/$defs/timeline_horizontal_slide"
+        },
+        {
+          "$ref": "#/$defs/title_subtitle_slide"
+        },
+        {
+          "$ref": "#/$defs/version_page_slide"
+        },
+        {
+          "$ref": "#/$defs/agenda_with_image_slide"
+        },
+        {
+          "$ref": "#/$defs/two_col_with_subtitle_slide"
+        },
+        {
+          "$ref": "#/$defs/three_col_with_subtitle_slide"
+        },
+        {
+          "$ref": "#/$defs/three_col_with_icons_slide"
+        },
+        {
+          "$ref": "#/$defs/five_col_with_icons_slide"
+        },
+        {
+          "$ref": "#/$defs/picture_compare_slide"
+        },
+        {
+          "$ref": "#/$defs/title_only_freeform_slide"
+        }
       ]
     },
-
     "image": {
       "oneOf": [
-        { "type": "string" },
+        {
+          "type": "string"
+        },
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["path"],
+          "required": [
+            "path"
+          ],
           "properties": {
-            "path": { "type": "string" },
-            "alt": { "type": "string" }
+            "path": {
+              "type": "string"
+            },
+            "alt": {
+              "type": "string"
+            }
           }
         }
       ]
     },
-
     "base_slide": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["archetype", "title"],
+      "required": [
+        "archetype",
+        "title"
+      ],
       "properties": {
-        "archetype": { "type": "string" },
-        "title": { "type": "string" },
-        "subtitle": { "type": "string" },
-        "body": { "type": "string" },
-        "bullets": { "type": "array", "items": { "type": "string" } },
-        "image": { "$ref": "#/$defs/image" },
-        "notes": { "type": "string" },
-
-        "table_text": { "type": "string" },
-        "col1_body": { "type": "string" },
-        "col2_body": { "type": "string" },
-        "col3_body": { "type": "string" },
-        "col4_body": { "type": "string" },
-        "pillar1_body": { "type": "string" },
-        "pillar2_body": { "type": "string" },
-        "pillar3_body": { "type": "string" },
-        "pillar4_body": { "type": "string" },
-
-        "milestone1_body": { "type": "string" },
-        "milestone2_body": { "type": "string" },
-        "milestone3_body": { "type": "string" },
-        "milestone4_body": { "type": "string" },
-        "milestone5_body": { "type": "string" },
-        "milestone6_body": { "type": "string" },
-        "milestone7_body": { "type": "string" },
-        "milestone8_body": { "type": "string" },
-        "milestone9_body": { "type": "string" },
-        "milestone10_body": { "type": "string" },
-
-        "items": { "type": "array" },
-        "left": { "type": "object" },
-        "right": { "type": "object" }
+        "archetype": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "subtitle": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "bullets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "image": {
+          "$ref": "#/$defs/image"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "table_text": {
+          "type": "string"
+        },
+        "col1_body": {
+          "type": "string"
+        },
+        "col2_body": {
+          "type": "string"
+        },
+        "col3_body": {
+          "type": "string"
+        },
+        "col4_body": {
+          "type": "string"
+        },
+        "pillar1_body": {
+          "type": "string"
+        },
+        "pillar2_body": {
+          "type": "string"
+        },
+        "pillar3_body": {
+          "type": "string"
+        },
+        "pillar4_body": {
+          "type": "string"
+        },
+        "milestone1_body": {
+          "type": "string"
+        },
+        "milestone2_body": {
+          "type": "string"
+        },
+        "milestone3_body": {
+          "type": "string"
+        },
+        "milestone4_body": {
+          "type": "string"
+        },
+        "milestone5_body": {
+          "type": "string"
+        },
+        "milestone6_body": {
+          "type": "string"
+        },
+        "milestone7_body": {
+          "type": "string"
+        },
+        "milestone8_body": {
+          "type": "string"
+        },
+        "milestone9_body": {
+          "type": "string"
+        },
+        "milestone10_body": {
+          "type": "string"
+        }
       }
     },
-
     "title_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "title" } },
-          "required": ["archetype", "title"]
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "title"
+            }
+          },
+          "required": [
+            "archetype",
+            "title"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "section_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "section" } },
-          "required": ["archetype", "title"]
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "section"
+            }
+          },
+          "required": [
+            "archetype",
+            "title"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "title_and_bullets_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "title_and_bullets" } },
-          "required": ["archetype", "title"],
-          "anyOf": [{ "required": ["bullets"] }, { "required": ["body"] }]
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "title_and_bullets"
+            }
+          },
+          "required": [
+            "archetype",
+            "title"
+          ],
+          "anyOf": [
+            {
+              "required": [
+                "bullets"
+              ]
+            },
+            {
+              "required": [
+                "body"
+              ]
+            }
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "title_subtitle_and_bullets_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "title_subtitle_and_bullets" } },
-          "required": ["archetype", "title", "subtitle"],
-          "anyOf": [{ "required": ["bullets"] }, { "required": ["body"] }]
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "title_subtitle_and_bullets"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "subtitle"
+          ],
+          "anyOf": [
+            {
+              "required": [
+                "bullets"
+              ]
+            },
+            {
+              "required": [
+                "body"
+              ]
+            }
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "image_left_text_right_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "image_left_text_right" } },
-          "required": ["archetype", "title", "body", "image"]
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "image_left_text_right"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "body",
+            "image"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "text_with_image_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "text_with_image" } },
-          "required": ["archetype", "title", "body", "image"]
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "text_with_image"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "body",
+            "image"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "two_col_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "two_col" } },
-          "required": ["archetype", "title", "col1_body", "col2_body"],
+          "$ref": "#/$defs/base_slide"
+        },
+        {
           "properties": {
-            "col1_body": { "type": "string" },
-            "col2_body": { "type": "string" }
-          }
+            "col1_body": {
+              "type": "string"
+            },
+            "col2_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "col1_body",
+            "col2_body"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "three_col_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "three_col" } },
-          "required": ["archetype", "title", "col1_body", "col2_body", "col3_body"],
+          "$ref": "#/$defs/base_slide"
+        },
+        {
           "properties": {
-            "col1_body": { "type": "string" },
-            "col2_body": { "type": "string" },
-            "col3_body": { "type": "string" }
-          }
+            "col1_body": {
+              "type": "string"
+            },
+            "col2_body": {
+              "type": "string"
+            },
+            "col3_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "col1_body",
+            "col2_body",
+            "col3_body"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "four_col_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "four_col" } },
-          "required": ["archetype", "title", "col1_body", "col2_body", "col3_body", "col4_body"],
+          "$ref": "#/$defs/base_slide"
+        },
+        {
           "properties": {
-            "col1_body": { "type": "string" },
-            "col2_body": { "type": "string" },
-            "col3_body": { "type": "string" },
-            "col4_body": { "type": "string" }
-          }
+            "col1_body": {
+              "type": "string"
+            },
+            "col2_body": {
+              "type": "string"
+            },
+            "col3_body": {
+              "type": "string"
+            },
+            "col4_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "col1_body",
+            "col2_body",
+            "col3_body",
+            "col4_body"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "pillars_3_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "pillars_3" } },
-          "required": ["archetype", "title", "pillar1_body", "pillar2_body", "pillar3_body"],
+          "$ref": "#/$defs/base_slide"
+        },
+        {
           "properties": {
-            "pillar1_body": { "type": "string" },
-            "pillar2_body": { "type": "string" },
-            "pillar3_body": { "type": "string" }
-          }
+            "pillar1_body": {
+              "type": "string"
+            },
+            "pillar2_body": {
+              "type": "string"
+            },
+            "pillar3_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "pillar1_body",
+            "pillar2_body",
+            "pillar3_body"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "pillars_4_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "pillars_4" } },
-          "required": ["archetype", "title", "pillar1_body", "pillar2_body", "pillar3_body", "pillar4_body"],
+          "$ref": "#/$defs/base_slide"
+        },
+        {
           "properties": {
-            "pillar1_body": { "type": "string" },
-            "pillar2_body": { "type": "string" },
-            "pillar3_body": { "type": "string" },
-            "pillar4_body": { "type": "string" }
-          }
+            "pillar1_body": {
+              "type": "string"
+            },
+            "pillar2_body": {
+              "type": "string"
+            },
+            "pillar3_body": {
+              "type": "string"
+            },
+            "pillar4_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "pillar1_body",
+            "pillar2_body",
+            "pillar3_body",
+            "pillar4_body"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "table_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "table" } },
-          "required": ["archetype", "title", "table_text"],
+          "$ref": "#/$defs/base_slide"
+        },
+        {
           "properties": {
-            "table_text": { "type": "string" }
-          }
+            "table_text": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "table_text"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "table_plus_description_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "table_plus_description" } },
-          "required": ["archetype", "title", "table_text", "body"],
+          "$ref": "#/$defs/base_slide"
+        },
+        {
           "properties": {
-            "table_text": { "type": "string" },
-            "body": { "type": "string" }
-          }
+            "table_text": {
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "table_text",
+            "body"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "timeline_horizontal_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
+        {
+          "$ref": "#/$defs/base_slide"
+        },
         {
           "properties": {
-            "archetype": { "const": "timeline_horizontal" },
-            "milestone1_body": { "type": "string" },
-            "milestone2_body": { "type": "string" },
-            "milestone3_body": { "type": "string" },
-            "milestone4_body": { "type": "string" },
-            "milestone5_body": { "type": "string" },
-            "milestone6_body": { "type": "string" },
-            "milestone7_body": { "type": "string" },
-            "milestone8_body": { "type": "string" },
-            "milestone9_body": { "type": "string" },
-            "milestone10_body": { "type": "string" }
+            "archetype": {
+              "const": "timeline_horizontal"
+            },
+            "milestone1_body": {
+              "type": "string"
+            },
+            "milestone2_body": {
+              "type": "string"
+            },
+            "milestone3_body": {
+              "type": "string"
+            },
+            "milestone4_body": {
+              "type": "string"
+            },
+            "milestone5_body": {
+              "type": "string"
+            },
+            "milestone6_body": {
+              "type": "string"
+            },
+            "milestone7_body": {
+              "type": "string"
+            },
+            "milestone8_body": {
+              "type": "string"
+            },
+            "milestone9_body": {
+              "type": "string"
+            },
+            "milestone10_body": {
+              "type": "string"
+            }
           },
-          "required": ["archetype", "title", "milestone1_body"]
+          "required": [
+            "archetype",
+            "title",
+            "milestone1_body"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "title_subtitle_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "title_subtitle" } },
-          "required": ["archetype", "title", "subtitle"]
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "title_subtitle"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "subtitle"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "version_page_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "version_page" } },
-          "required": ["archetype", "title", "table_text"],
+          "$ref": "#/$defs/base_slide"
+        },
+        {
           "properties": {
-            "table_text": { "type": "string" }
-          }
+            "table_text": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "table_text"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "agenda_item": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["body"],
+      "required": [
+        "body"
+      ],
       "properties": {
-        "marker": { "type": "string" },
-        "body": { "type": "string" }
+        "marker": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        }
       }
     },
-
     "agenda_with_image_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
+        {
+          "$ref": "#/$defs/base_slide"
+        },
         {
           "properties": {
-            "archetype": { "const": "agenda_with_image" },
-            "image": { "$ref": "#/$defs/image" },
+            "archetype": {
+              "const": "agenda_with_image"
+            },
+            "image": {
+              "$ref": "#/$defs/image"
+            },
             "items": {
               "type": "array",
               "minItems": 1,
-              "items": { "$ref": "#/$defs/agenda_item" }
+              "items": {
+                "$ref": "#/$defs/agenda_item"
+              }
             }
           },
-          "required": ["archetype", "title", "image", "items"]
+          "required": [
+            "archetype",
+            "title",
+            "image",
+            "items"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "two_col_with_subtitle_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "two_col_with_subtitle" } },
-          "required": ["archetype", "title", "subtitle", "col1_body", "col2_body"],
+          "$ref": "#/$defs/base_slide"
+        },
+        {
           "properties": {
-            "col1_body": { "type": "string" },
-            "col2_body": { "type": "string" }
-          }
+            "col1_body": {
+              "type": "string"
+            },
+            "col2_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "subtitle",
+            "col1_body",
+            "col2_body"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "three_col_text_item": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["body"],
+      "required": [
+        "body"
+      ],
       "properties": {
-        "title": { "type": "string" },
-        "body": { "type": "string" }
+        "title": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        }
       }
     },
-
     "three_col_with_subtitle_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
+        {
+          "$ref": "#/$defs/base_slide"
+        },
         {
           "properties": {
-            "archetype": { "const": "three_col_with_subtitle" },
+            "archetype": {
+              "const": "three_col_with_subtitle"
+            },
             "items": {
               "type": "array",
               "minItems": 1,
-              "items": { "$ref": "#/$defs/three_col_text_item" }
+              "items": {
+                "$ref": "#/$defs/three_col_text_item"
+              }
             }
           },
-          "required": ["archetype", "title", "subtitle", "items"]
+          "required": [
+            "archetype",
+            "title",
+            "subtitle",
+            "items"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "icon_col_item": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["title", "body", "icon"],
+      "required": [
+        "title",
+        "body",
+        "icon"
+      ],
       "properties": {
-        "title": { "type": "string" },
-        "body": { "type": "string" },
-        "caption": { "type": "string" },
-        "icon": { "$ref": "#/$defs/image" }
+        "title": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "caption": {
+          "type": "string"
+        },
+        "icon": {
+          "$ref": "#/$defs/image"
+        }
       }
     },
-
     "three_col_with_icons_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
+        {
+          "$ref": "#/$defs/base_slide"
+        },
         {
           "properties": {
-            "archetype": { "const": "three_col_with_icons" },
+            "archetype": {
+              "const": "three_col_with_icons"
+            },
             "items": {
               "type": "array",
               "minItems": 1,
-              "items": { "$ref": "#/$defs/icon_col_item" }
+              "items": {
+                "$ref": "#/$defs/icon_col_item"
+              }
             }
           },
-          "required": ["archetype", "title", "items"]
+          "required": [
+            "archetype",
+            "title",
+            "items"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "five_col_icon_item": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["icon", "body"],
+      "required": [
+        "icon",
+        "body"
+      ],
       "properties": {
-        "body": { "type": "string" },
-        "icon": { "$ref": "#/$defs/image" }
+        "body": {
+          "type": "string"
+        },
+        "icon": {
+          "$ref": "#/$defs/image"
+        }
       }
     },
-
     "five_col_with_icons_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
+        {
+          "$ref": "#/$defs/base_slide"
+        },
         {
           "properties": {
-            "archetype": { "const": "five_col_with_icons" },
+            "archetype": {
+              "const": "five_col_with_icons"
+            },
             "items": {
               "type": "array",
               "minItems": 1,
-              "items": { "$ref": "#/$defs/five_col_icon_item" }
+              "items": {
+                "$ref": "#/$defs/five_col_icon_item"
+              }
             }
           },
-          "required": ["archetype", "title", "items"]
+          "required": [
+            "archetype",
+            "title",
+            "items"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "picture_compare_side": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["image"],
+      "required": [
+        "image"
+      ],
       "properties": {
-        "image": { "$ref": "#/$defs/image" },
-        "title": { "type": "string" },
-        "body": { "type": "string" }
+        "image": {
+          "$ref": "#/$defs/image"
+        },
+        "title": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        }
       }
     },
-
     "picture_compare_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
+        {
+          "$ref": "#/$defs/base_slide"
+        },
         {
           "properties": {
-            "archetype": { "const": "picture_compare" },
-            "left": { "$ref": "#/$defs/picture_compare_side" },
-            "right": { "$ref": "#/$defs/picture_compare_side" }
+            "archetype": {
+              "const": "picture_compare"
+            },
+            "left": {
+              "$ref": "#/$defs/picture_compare_side"
+            },
+            "right": {
+              "$ref": "#/$defs/picture_compare_side"
+            }
           },
-          "required": ["archetype", "title", "left", "right"]
+          "required": [
+            "archetype",
+            "title",
+            "left",
+            "right"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     },
-
     "title_only_freeform_slide": {
       "allOf": [
-        { "$ref": "#/$defs/base_slide" },
         {
-          "properties": { "archetype": { "const": "title_only_freeform" } },
-          "required": ["archetype", "title"]
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "title_only_freeform"
+            }
+          },
+          "required": [
+            "archetype",
+            "title"
+          ],
+          "unevaluatedProperties": false
         }
       ]
     }


### PR DESCRIPTION
## Summary

Tightens deck spec JSON Schema by using `unevaluatedProperties: false` on slide archetype schemas.

This avoids needing `base_slide.additionalProperties=false` (which forced base_slide to enumerate every possible property across all archetypes).

Key changes:
- Removes `additionalProperties: false` from `base_slide`
- Removes generic `items/left/right` from `base_slide`
- Adds `unevaluatedProperties: false` to each `*_slide` schema so extra fields are rejected unless defined by the archetype

Fixes #119
