### PR TITLE
fix: package deck-spec schema to avoid outdated install validation (issue #127)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,6 @@ package-dir = {"" = "src"}
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+slide_smith = ["schemas/*.json"]

--- a/src/slide_smith/commands/create.py
+++ b/src/slide_smith/commands/create.py
@@ -57,6 +57,19 @@ def handle_create(
         schema_res = validate_against_schema(spec)
         if not schema_res.ok:
             lines = ["Deck spec schema validation failed:"] + [f"- {e}" for e in schema_res.errors]
+
+            # Heuristic: if lightweight validation passed but schema failed with
+            # oneOf mismatch, users are likely running an outdated schema (older
+            # install) that doesn't include the new archetype ids.
+            if any("is not valid under any of the given schemas" in e for e in schema_res.errors):
+                try:
+                    from slide_smith.schema_validation import _schema_path
+
+                    lines.append(f"- hint: schema path in use: {_schema_path()}")
+                    lines.append("- hint: if this schema is missing your archetype ids, upgrade slide-smith or run from repo HEAD")
+                except Exception:
+                    lines.append("- hint: upgrade slide-smith or run from repo HEAD (schema may be outdated)")
+
             return 1, "\n".join(lines)
     except Exception:
         pass

--- a/src/slide_smith/schema_validation.py
+++ b/src/slide_smith/schema_validation.py
@@ -13,7 +13,25 @@ class SchemaValidationResult:
 
 
 def _schema_path() -> Path:
-    # repo-local path
+    """Locate the deck spec JSON schema.
+
+    Preference order:
+    1) Packaged schema within the slide_smith module (works for installed wheels)
+    2) Repo-local schema under docs/ (works in a source checkout)
+
+    This avoids a common failure mode where an older installed version validates
+    against an outdated schema (or a schema file is missing from the package).
+    """
+
+    # 1) packaged schema
+    try:  # pragma: no cover
+        from importlib import resources
+
+        return resources.files("slide_smith").joinpath("schemas/deck-spec.schema.json")  # type: ignore[return-value]
+    except Exception:
+        pass
+
+    # 2) repo-local path
     return Path(__file__).resolve().parents[2] / "docs" / "design" / "deck-spec.schema.json"
 
 

--- a/src/slide_smith/schemas/deck-spec.schema.json
+++ b/src/slide_smith/schemas/deck-spec.schema.json
@@ -1,0 +1,904 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/slide-smith/deck-spec.schema.json",
+  "title": "slide_smith deck spec",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "slides"
+  ],
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "subtitle": {
+      "type": "string"
+    },
+    "slides": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/slide"
+      }
+    }
+  },
+  "$defs": {
+    "slide": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/title_slide"
+        },
+        {
+          "$ref": "#/$defs/section_slide"
+        },
+        {
+          "$ref": "#/$defs/title_and_bullets_slide"
+        },
+        {
+          "$ref": "#/$defs/title_subtitle_and_bullets_slide"
+        },
+        {
+          "$ref": "#/$defs/image_left_text_right_slide"
+        },
+        {
+          "$ref": "#/$defs/text_with_image_slide"
+        },
+        {
+          "$ref": "#/$defs/two_col_slide"
+        },
+        {
+          "$ref": "#/$defs/three_col_slide"
+        },
+        {
+          "$ref": "#/$defs/four_col_slide"
+        },
+        {
+          "$ref": "#/$defs/pillars_3_slide"
+        },
+        {
+          "$ref": "#/$defs/pillars_4_slide"
+        },
+        {
+          "$ref": "#/$defs/table_slide"
+        },
+        {
+          "$ref": "#/$defs/table_plus_description_slide"
+        },
+        {
+          "$ref": "#/$defs/timeline_horizontal_slide"
+        },
+        {
+          "$ref": "#/$defs/title_subtitle_slide"
+        },
+        {
+          "$ref": "#/$defs/version_page_slide"
+        },
+        {
+          "$ref": "#/$defs/agenda_with_image_slide"
+        },
+        {
+          "$ref": "#/$defs/two_col_with_subtitle_slide"
+        },
+        {
+          "$ref": "#/$defs/three_col_with_subtitle_slide"
+        },
+        {
+          "$ref": "#/$defs/three_col_with_icons_slide"
+        },
+        {
+          "$ref": "#/$defs/five_col_with_icons_slide"
+        },
+        {
+          "$ref": "#/$defs/picture_compare_slide"
+        },
+        {
+          "$ref": "#/$defs/title_only_freeform_slide"
+        }
+      ]
+    },
+    "image": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "path"
+          ],
+          "properties": {
+            "path": {
+              "type": "string"
+            },
+            "alt": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "base_slide": {
+      "type": "object",
+      "required": [
+        "archetype",
+        "title"
+      ],
+      "properties": {
+        "archetype": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "subtitle": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "bullets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "image": {
+          "$ref": "#/$defs/image"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "table_text": {
+          "type": "string"
+        },
+        "col1_body": {
+          "type": "string"
+        },
+        "col2_body": {
+          "type": "string"
+        },
+        "col3_body": {
+          "type": "string"
+        },
+        "col4_body": {
+          "type": "string"
+        },
+        "pillar1_body": {
+          "type": "string"
+        },
+        "pillar2_body": {
+          "type": "string"
+        },
+        "pillar3_body": {
+          "type": "string"
+        },
+        "pillar4_body": {
+          "type": "string"
+        },
+        "milestone1_body": {
+          "type": "string"
+        },
+        "milestone2_body": {
+          "type": "string"
+        },
+        "milestone3_body": {
+          "type": "string"
+        },
+        "milestone4_body": {
+          "type": "string"
+        },
+        "milestone5_body": {
+          "type": "string"
+        },
+        "milestone6_body": {
+          "type": "string"
+        },
+        "milestone7_body": {
+          "type": "string"
+        },
+        "milestone8_body": {
+          "type": "string"
+        },
+        "milestone9_body": {
+          "type": "string"
+        },
+        "milestone10_body": {
+          "type": "string"
+        }
+      }
+    },
+    "title_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "title"
+            }
+          },
+          "required": [
+            "archetype",
+            "title"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "section_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "section"
+            }
+          },
+          "required": [
+            "archetype",
+            "title"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "title_and_bullets_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "title_and_bullets"
+            }
+          },
+          "required": [
+            "archetype",
+            "title"
+          ],
+          "anyOf": [
+            {
+              "required": [
+                "bullets"
+              ]
+            },
+            {
+              "required": [
+                "body"
+              ]
+            }
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "title_subtitle_and_bullets_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "title_subtitle_and_bullets"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "subtitle"
+          ],
+          "anyOf": [
+            {
+              "required": [
+                "bullets"
+              ]
+            },
+            {
+              "required": [
+                "body"
+              ]
+            }
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "image_left_text_right_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "image_left_text_right"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "body",
+            "image"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "text_with_image_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "text_with_image"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "body",
+            "image"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "two_col_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "col1_body": {
+              "type": "string"
+            },
+            "col2_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "col1_body",
+            "col2_body"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "three_col_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "col1_body": {
+              "type": "string"
+            },
+            "col2_body": {
+              "type": "string"
+            },
+            "col3_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "col1_body",
+            "col2_body",
+            "col3_body"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "four_col_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "col1_body": {
+              "type": "string"
+            },
+            "col2_body": {
+              "type": "string"
+            },
+            "col3_body": {
+              "type": "string"
+            },
+            "col4_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "col1_body",
+            "col2_body",
+            "col3_body",
+            "col4_body"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "pillars_3_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "pillar1_body": {
+              "type": "string"
+            },
+            "pillar2_body": {
+              "type": "string"
+            },
+            "pillar3_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "pillar1_body",
+            "pillar2_body",
+            "pillar3_body"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "pillars_4_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "pillar1_body": {
+              "type": "string"
+            },
+            "pillar2_body": {
+              "type": "string"
+            },
+            "pillar3_body": {
+              "type": "string"
+            },
+            "pillar4_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "pillar1_body",
+            "pillar2_body",
+            "pillar3_body",
+            "pillar4_body"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "table_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "table_text": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "table_text"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "table_plus_description_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "table_text": {
+              "type": "string"
+            },
+            "body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "table_text",
+            "body"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "timeline_horizontal_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "timeline_horizontal"
+            },
+            "milestone1_body": {
+              "type": "string"
+            },
+            "milestone2_body": {
+              "type": "string"
+            },
+            "milestone3_body": {
+              "type": "string"
+            },
+            "milestone4_body": {
+              "type": "string"
+            },
+            "milestone5_body": {
+              "type": "string"
+            },
+            "milestone6_body": {
+              "type": "string"
+            },
+            "milestone7_body": {
+              "type": "string"
+            },
+            "milestone8_body": {
+              "type": "string"
+            },
+            "milestone9_body": {
+              "type": "string"
+            },
+            "milestone10_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "milestone1_body"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "title_subtitle_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "title_subtitle"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "subtitle"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "version_page_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "table_text": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "table_text"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "agenda_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "body"
+      ],
+      "properties": {
+        "marker": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        }
+      }
+    },
+    "agenda_with_image_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "agenda_with_image"
+            },
+            "image": {
+              "$ref": "#/$defs/image"
+            },
+            "items": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/agenda_item"
+              }
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "image",
+            "items"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "two_col_with_subtitle_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "col1_body": {
+              "type": "string"
+            },
+            "col2_body": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "subtitle",
+            "col1_body",
+            "col2_body"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "three_col_text_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "body"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        }
+      }
+    },
+    "three_col_with_subtitle_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "three_col_with_subtitle"
+            },
+            "items": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/three_col_text_item"
+              }
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "subtitle",
+            "items"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "icon_col_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "title",
+        "body",
+        "icon"
+      ],
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "caption": {
+          "type": "string"
+        },
+        "icon": {
+          "$ref": "#/$defs/image"
+        }
+      }
+    },
+    "three_col_with_icons_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "three_col_with_icons"
+            },
+            "items": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/icon_col_item"
+              }
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "items"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "five_col_icon_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "icon",
+        "body"
+      ],
+      "properties": {
+        "body": {
+          "type": "string"
+        },
+        "icon": {
+          "$ref": "#/$defs/image"
+        }
+      }
+    },
+    "five_col_with_icons_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "five_col_with_icons"
+            },
+            "items": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/$defs/five_col_icon_item"
+              }
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "items"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "picture_compare_side": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "image"
+      ],
+      "properties": {
+        "image": {
+          "$ref": "#/$defs/image"
+        },
+        "title": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        }
+      }
+    },
+    "picture_compare_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "picture_compare"
+            },
+            "left": {
+              "$ref": "#/$defs/picture_compare_side"
+            },
+            "right": {
+              "$ref": "#/$defs/picture_compare_side"
+            }
+          },
+          "required": [
+            "archetype",
+            "title",
+            "left",
+            "right"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    },
+    "title_only_freeform_slide": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_slide"
+        },
+        {
+          "properties": {
+            "archetype": {
+              "const": "title_only_freeform"
+            }
+          },
+          "required": [
+            "archetype",
+            "title"
+          ],
+          "unevaluatedProperties": false
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes a common cause of "create rejects new archetypes" by ensuring the deck spec JSON schema is packaged with the module and used consistently.

## Changes

- Adds packaged schema at `src/slide_smith/schemas/deck-spec.schema.json`
- Updates schema lookup to prefer packaged schema via `importlib.resources` (works for installed wheels)
- Adds a hint to `create` when schema fails with oneOf mismatch, pointing to the schema path in use + upgrade guidance

Fixes #127
