### PR TITLE
fix: improve mapper inference for Agentic COE simple template (issue #129)

### DIFF
--- a/src/slide_smith/template_mapper.py
+++ b/src/slide_smith/template_mapper.py
@@ -119,6 +119,11 @@ def _pick_best(archetypes: Iterable[dict[str, Any]], scorer) -> InferenceCandida
     return best
 
 
+def _layout_name(a: dict[str, Any]) -> str:
+    v = a.get("layout")
+    return v if isinstance(v, str) else ""
+
+
 def infer_standard_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
     """Return an updated template spec with best-effort standard archetypes added.
 
@@ -137,7 +142,15 @@ def infer_standard_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
         if c["title"] < 1:
             return 0.0, "missing title slot"
         score = 5 + 2 * min(c["subtitle"], 1) - 2 * c["image"] - 1 * c["bullets"]
-        return float(score), f"title={c['title']} subtitle={c['subtitle']} image={c['image']} bullets={c['bullets']}"
+
+        ln = _layout_name(a).lower()
+        # Heuristics for branded templates: prefer explicit cover layouts.
+        if "cover" in ln:
+            score += 8
+        if "session" in ln:
+            score -= 6
+
+        return float(score), f"layout={_layout_name(a)} title={c['title']} subtitle={c['subtitle']} image={c['image']} bullets={c['bullets']}"
 
     def score_section(a: dict[str, Any]):
         c = _slot_counts(a)
@@ -145,7 +158,15 @@ def infer_standard_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
             return 0.0, "missing title slot"
         # section often looks like title slide but can be simpler.
         score = 4 + 1 * min(c["subtitle"], 1) + 1 * min(c["body"], 1) - 2 * c["image"]
-        return float(score), f"title={c['title']} subtitle={c['subtitle']} body={c['body']} image={c['image']}"
+
+        ln = _layout_name(a).lower()
+        # Prefer explicit section-divider layouts.
+        if "session" in ln:
+            score += 8
+        if "cover" in ln:
+            score -= 6
+
+        return float(score), f"layout={_layout_name(a)} title={c['title']} subtitle={c['subtitle']} body={c['body']} image={c['image']}"
 
     def score_title_and_bullets(a: dict[str, Any]):
         c = _slot_counts(a)
@@ -154,7 +175,15 @@ def infer_standard_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
         if c["bullets"] < 1 and c["body"] < 1:
             return 0.0, "missing bullets/body slot"
         score = 6 + 2 * min(c["bullets"], 1) + 1 * min(c["body"], 1) - 3 * c["image"]
-        return float(score), f"title={c['title']} bullets={c['bullets']} body={c['body']} image={c['image']}"
+
+        ln = _layout_name(a).lower()
+        # Prefer explicit content-box layouts over title/subtitle framing layouts.
+        if "content-box" in ln or "content box" in ln:
+            score += 8
+        if "subtitle only" in ln:
+            score -= 6
+
+        return float(score), f"layout={_layout_name(a)} title={c['title']} bullets={c['bullets']} body={c['body']} image={c['image']}"
 
     def score_image_left_text_right(a: dict[str, Any]):
         c = _slot_counts(a)
@@ -165,7 +194,15 @@ def infer_standard_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
         if c["body"] < 1 and c["bullets"] < 1:
             return 0.0, "missing body slot"
         score = 7 + 2 * min(c["image"], 1) + 1 * min(c["body"], 1) + 1 * min(c["bullets"], 1)
-        return float(score), f"title={c['title']} image={c['image']} body={c['body']} bullets={c['bullets']}"
+
+        ln = _layout_name(a).lower()
+        # Prefer generic content layouts over specialized agenda layouts.
+        if "column + image" in ln or "column" in ln and "image" in ln:
+            score += 8
+        if "agenda" in ln:
+            score -= 8
+
+        return float(score), f"layout={_layout_name(a)} title={c['title']} image={c['image']} body={c['body']} bullets={c['bullets']}"
 
     def score_title_subtitle_and_bullets(a: dict[str, Any]):
         c = _slot_counts(a)

--- a/src/slide_smith/template_mapper_extended.py
+++ b/src/slide_smith/template_mapper_extended.py
@@ -46,6 +46,11 @@ def _placeholder_idxs(a: dict[str, Any]) -> list[int]:
     return sorted(set(out))
 
 
+def _layout_name(a: dict[str, Any]) -> str:
+    v = a.get("layout")
+    return v if isinstance(v, str) else ""
+
+
 def infer_extended_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
     archetypes = [a for a in (template_spec.get("archetypes") or []) if isinstance(a, dict)]
 
@@ -96,9 +101,16 @@ def infer_extended_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
         score = 6.0 + 3.0 * min(subtitles, 1) - 1.0 * bodies - 2.0 * images
         if subtitles < 1:
             score -= 4.0
-        return score, f"subtitles={subtitles} bodies={bodies} images={images} idxs={_placeholder_idxs(a)}"
 
-    def score_icons_cols(n: int):
+        ln = _layout_name(a).lower()
+        if "title subtitle only" in ln:
+            score += 10
+        if "session" in ln:
+            score -= 6
+
+        return score, f"layout={_layout_name(a)} subtitles={subtitles} bodies={bodies} images={images} idxs={_placeholder_idxs(a)}"
+
+    def score_icons_cols(n: int, *, prefer_layout_contains: str | None = None):
         def _score(a: dict[str, Any]):
             if not _has_title(a):
                 return 0.0, "missing title"
@@ -108,7 +120,12 @@ def infer_extended_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
             score = 5.0 + 2.0 * min(images, n) + 1.5 * min(bodies, n)
             if images < n:
                 score -= (n - images) * 4.0
-            return score, f"images={images} bodies={bodies} idxs={_placeholder_idxs(a)}"
+
+            ln = _layout_name(a).lower()
+            if prefer_layout_contains and prefer_layout_contains.lower() in ln:
+                score += 12
+
+            return score, f"layout={_layout_name(a)} images={images} bodies={bodies} idxs={_placeholder_idxs(a)}"
 
         return _score
 
@@ -120,12 +137,17 @@ def infer_extended_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
         score = 6.0 + 2.5 * min(images, 2) + 1.0 * min(bodies, 2)
         if images < 2:
             score -= 6.0
-        return score, f"images={images} bodies={bodies} idxs={_placeholder_idxs(a)}"
+
+        ln = _layout_name(a).lower()
+        if "picture compare" in ln:
+            score += 14
+
+        return score, f"layout={_layout_name(a)} images={images} bodies={bodies} idxs={_placeholder_idxs(a)}"
 
     # Redesign extended archetypes (best-effort inference)
     picks["title_subtitle"] = pick_best(score_title_subtitle)
-    picks["three_col_with_icons"] = pick_best(score_icons_cols(3))
-    picks["five_col_with_icons"] = pick_best(score_icons_cols(5))
+    picks["three_col_with_icons"] = pick_best(score_icons_cols(3, prefer_layout_contains="3 columns with icons"))
+    picks["five_col_with_icons"] = pick_best(score_icons_cols(5, prefer_layout_contains="5 columns"))
     picks["picture_compare"] = pick_best(score_picture_compare)
 
     def score_table(a: dict[str, Any]):
@@ -156,7 +178,7 @@ def infer_extended_mappings(template_spec: dict[str, Any]) -> dict[str, Any]:
         bodies = _count_slot(a, want_type="bullets") + _count_slot(a, want_name_prefix="body")
         # Timeline often has multiple similar placeholders.
         score = 4.0 + 1.5 * min(bodies, 5)
-        return score, f"bodies={bodies} idxs={_placeholder_idxs(a)}"
+        return score, f"layout={_layout_name(a)} bodies={bodies} idxs={_placeholder_idxs(a)}"
 
     picks["timeline_horizontal"] = pick_best(score_timeline)
 

--- a/tests/test_template_mapper_agentic_coe_simple_heuristics.py
+++ b/tests/test_template_mapper_agentic_coe_simple_heuristics.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from slide_smith.template_mapper import infer_standard_mappings
+from slide_smith.template_mapper_extended import infer_extended_mappings
+
+
+def _layout_archetype(aid: str, layout: str, *, title: bool = True, subtitle: bool = False, bullets: bool = False, body: bool = False, image: int = 0):
+    slots = []
+    if title:
+        slots.append({"name": "title", "type": "text", "placeholder_idx": 0})
+    if subtitle:
+        slots.append({"name": "subtitle", "type": "text", "placeholder_idx": 10})
+    if bullets:
+        slots.append({"name": "bullets", "type": "bullets", "placeholder_idx": 11})
+    if body:
+        slots.append({"name": "body", "type": "text", "placeholder_idx": 12})
+    for i in range(image):
+        slots.append({"name": f"image{i+1}", "type": "image", "placeholder_idx": 20 + i})
+    return {"id": aid, "layout": layout, "slots": slots}
+
+
+def test_standard_mapper_prefers_cover_for_title_and_session_for_section() -> None:
+    spec = {
+        "archetypes": [
+            _layout_archetype("layout__cover", "Cover: light mode", subtitle=True),
+            _layout_archetype("layout__session", "Session"),
+        ]
+    }
+    out = infer_standard_mappings(spec)
+    by_id = {a["id"]: a for a in out["archetypes"] if isinstance(a, dict) and isinstance(a.get("id"), str)}
+
+    assert by_id["title"]["layout"] == "Cover: light mode"
+    assert by_id["section"]["layout"] == "Session"
+
+
+def test_standard_mapper_prefers_content_box_for_title_and_bullets() -> None:
+    spec = {
+        "archetypes": [
+            _layout_archetype("layout__content_box", "Content: title content-box", bullets=True),
+            _layout_archetype("layout__subtitle_only", "Content: title subtitle only", subtitle=True, bullets=True),
+        ]
+    }
+    out = infer_standard_mappings(spec)
+    by_id = {a["id"]: a for a in out["archetypes"] if isinstance(a, dict) and isinstance(a.get("id"), str)}
+
+    assert by_id["title_and_bullets"]["layout"] == "Content: title content-box"
+
+
+def test_standard_mapper_prefers_column_image_for_text_with_image_over_agenda() -> None:
+    spec = {
+        "archetypes": [
+            _layout_archetype("layout__agenda", "Agenda: image", body=True, image=1),
+            _layout_archetype("layout__col_img", "Content: column + image", body=True, image=1),
+        ]
+    }
+    out = infer_standard_mappings(spec)
+    by_id = {a["id"]: a for a in out["archetypes"] if isinstance(a, dict) and isinstance(a.get("id"), str)}
+
+    assert by_id["text_with_image"]["layout"] == "Content: column + image"
+
+
+def test_extended_mapper_prefers_explicit_3_col_icons_and_picture_compare() -> None:
+    spec = {
+        "archetypes": [
+            _layout_archetype("layout__3icons", "Content: 3 columns with icons", body=True, image=3),
+            _layout_archetype("layout__5icons", "Content: 5 columns with icon", body=True, image=5),
+            _layout_archetype("layout__compare", "Content: picture compare", body=True, image=2),
+        ]
+    }
+
+    out = infer_extended_mappings(spec)
+    by_id = {a["id"]: a for a in out["archetypes"] if isinstance(a, dict) and isinstance(a.get("id"), str)}
+
+    assert by_id["three_col_with_icons"]["layout"] == "Content: 3 columns with icons"
+    assert by_id["picture_compare"]["layout"] == "Content: picture compare"


### PR DESCRIPTION
## Summary

Fixes the mapper inference failures called out in #129 by adding layout-name heuristics for the Agentic COE 2026 simple template (and similar branded templates).

## Changes

- Standard mapper now strongly prefers:
  - `Cover:*` layouts for `title`
  - `Session` layouts for `section`
  - `*content-box*` layouts for `title_and_bullets`
  - `*column + image*` layouts for `text_with_image` (and avoids `Agenda:*`)

- Extended mapper now prefers explicit layouts:
  - `*title subtitle only*` for `title_subtitle`
  - `*3 columns with icons*` for `three_col_with_icons`
  - `*picture compare*` for `picture_compare`

- Adds regression tests with a synthetic bootstrap inventory to assert the preferred layouts win.

Fixes #129
